### PR TITLE
Send oauth_callback parameter to Twitter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,15 +89,7 @@ Further documentation at `Twitter development resources`_:
       TWITTER_CONSUMER_KEY
       TWITTER_CONSUMER_SECRET
 
-Twitter demands a redirect url configuration and will force the user
-to that address when redirecting, and http://127.0.0.1:8000 won't 
-work. As a development hack, I suggest to setup something like
-http://myvirtualapp.com and adding an entry in /etc/hosts for that
-address pointing to localhost, port will be missed, but will do the
-trick for testing.
-
-If you cannot resit the missing port issue, play a bit with dnsmasq_.
-
+  - You don't need to specify the url callback
 
 --------
 Facebook

--- a/social_auth/auth.py
+++ b/social_auth/auth.py
@@ -8,6 +8,7 @@ from openid.extensions import sreg, ax
 from django.conf import settings
 from django.utils import simplejson
 from django.contrib.auth import authenticate
+from django.core.urlresolvers import reverse
 
 from .base import BaseAuth
 from .store import DjangoOpenIDStore
@@ -110,6 +111,10 @@ class YahooAuth(OpenIdAuth):
 
 class TwitterAuth(BaseAuth):
     """Twitter OAuth authentication mechanism"""
+    def __init__(self, request, redirect):
+        super(TwitterAuth, self).__init__(request, redirect)
+        self.redirect_uri = self.request.build_absolute_uri(reverse('social:complete', args=['twitter']))
+
     def auth_url(self):
         """Returns redirect url"""
         token = self.unauthorized_token()
@@ -149,7 +154,8 @@ class TwitterAuth(BaseAuth):
             return None
 
     def oauth_request(self, token, url):
-        request = OAuthRequest.from_consumer_and_token(self.consumer, token=token, http_url=url)
+        params = {'oauth_callback': self.redirect_uri}
+        request = OAuthRequest.from_consumer_and_token(self.consumer, token=token, http_url=url, parameters=params)
         request.sign_request(OAuthSignatureMethod_HMAC_SHA1(), self.consumer, token)
         return request
 


### PR DESCRIPTION
According to the Twitter wiki (http://dev.twitter.com/pages/auth), "Always use an explicit oauth_callback".

So I made some changes in auth.py to send oauth_callback automatically. Take a look.
