### PR TITLE
Fixed security hole with unsanitized redirects

### DIFF
--- a/social_auth/utils.py
+++ b/social_auth/utils.py
@@ -1,0 +1,18 @@
+import urlparse
+
+def sanitize_redirect(host, redirect_to):
+    """
+    Given the hostname and an untrusted URL to redirect to,
+    this method tests it to make sure it isn't garbage/harmful
+    and returns it, else returns None.
+
+    See http://code.djangoproject.com/browser/django/trunk/django/contrib/auth/views.py#L36
+    """
+    # Quick sanity check.
+    if not redirect_to:
+        return None
+    netloc = urlparse.urlparse(redirect_to)[1]
+    # Heavier security check -- don't allow redirection to a different host.
+    if netloc and netloc != host:
+        return None
+    return redirect_to

--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -1,21 +1,23 @@
 """Views"""
 from django.conf import settings
-from django.http import HttpResponseRedirect, HttpResponse, \
-                        HttpResponseServerError
+from django.http import HttpResponseRedirect, HttpResponse, HttpResponseServerError
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.contrib.auth import login, REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
 
 from social_auth.backends import get_backend
+from social_auth.utils import sanitize_redirect
+
+
+DEFAULT_REDIRECT = getattr(settings, 'LOGIN_REDIRECT_URL', '')
 
 
 def auth(request, backend):
     """Start authentication process"""
     complete_url = getattr(settings, 'SOCIAL_AUTH_COMPLETE_URL_NAME',
                            'complete')
-    redirect = getattr(settings, 'LOGIN_REDIRECT_URL', '')
-    return auth_process(request, backend, complete_url, redirect)
+    return auth_process(request, backend, complete_url)
 
 
 @transaction.commit_on_success
@@ -47,8 +49,7 @@ def complete_process(request, backend):
             social_user = user.social_auth.get(provider=backend_name)
             if social_user.expiration_delta():
                 request.session.set_expiry(social_user.expiration_delta())
-        url = request.session.pop(REDIRECT_FIELD_NAME, '') or \
-              getattr(settings, 'LOGIN_REDIRECT_URL', '')
+        url = request.session.pop(REDIRECT_FIELD_NAME, '') or DEFAULT_REDIRECT
     else:
         url = getattr(settings, 'LOGIN_ERROR_URL', settings.LOGIN_URL)
     return HttpResponseRedirect(url)
@@ -59,8 +60,7 @@ def associate(request, backend):
     """Authentication starting process"""
     complete_url = getattr(settings, 'SOCIAL_AUTH_ASSOCIATE_URL_NAME',
                            'associate_complete')
-    redirect = getattr(settings, 'LOGIN_REDIRECT_URL', '')
-    return auth_process(request, backend, complete_url, redirect)
+    return auth_process(request, backend, complete_url)
 
 
 @login_required
@@ -70,8 +70,7 @@ def associate_complete(request, backend):
     if not backend:
         return HttpResponseServerError('Incorrect authentication service')
     backend.auth_complete(user=request.user)
-    url = request.session.pop(REDIRECT_FIELD_NAME, '') or \
-          getattr(settings, 'LOGIN_REDIRECT_URL', '')
+    url = request.session.pop(REDIRECT_FIELD_NAME, '') or DEFAULT_REDIRECT
     return HttpResponseRedirect(url)
 
 
@@ -82,20 +81,21 @@ def disconnect(request, backend):
     if not backend:
         return HttpResponseServerError('Incorrect authentication service')
     backend.disconnect(request.user)
-    url = request.REQUEST.get(REDIRECT_FIELD_NAME, '') or \
-          getattr(settings, 'LOGIN_REDIRECT_URL', '')
+    url = request.REQUEST.get(REDIRECT_FIELD_NAME, '') or DEFAULT_REDIRECT
     return HttpResponseRedirect(url)
 
 
-def auth_process(request, backend, complete_url_name, default_final_url):
+def auth_process(request, backend, complete_url_name, 
+                 default_redirect=DEFAULT_REDIRECT):
     """Authenticate using social backend"""
     redirect = reverse(complete_url_name, args=(backend,))
     backend = get_backend(backend, request, redirect)
     if not backend:
         return HttpResponseServerError('Incorrect authentication service')
     data = request.REQUEST
-    request.session[REDIRECT_FIELD_NAME] = data.get(REDIRECT_FIELD_NAME,
-                                                    default_final_url)
+    # Check and sanitize a user-defined GET/POST redirect_to field value.
+    redirect = sanitize_redirect(request.get_host(), data.get(REDIRECT_FIELD_NAME))
+    request.session[REDIRECT_FIELD_NAME] = redirect or DEFAULT_REDIRECT
     if backend.uses_redirect:
         return HttpResponseRedirect(backend.auth_url())
     else:


### PR DESCRIPTION
Hi,

The basic premise behind this fix is that this app supports providing a redirect via a technically user-definable GET _or_ POST field value, very much like how django.contrib.auth does but it _doesn't_ sanitise it like Django and this allows someone to redirect to a different host after any given login e.g http://www.my-deployment-with-social-auth.com/associate/google/?next=http://www.a-nasty-phishing-site.com/login/

I don't actually have a project running with this app but I replicated it with the built in example app and my changes sorted the problem there. 

More on why it's dangerous here: http://www.djm.org.uk/djangos-little-protections-word-redirect-dangers/ and a bit of conversation here: https://convore.com/django-community/redirect-user-to-the-page-they-first-asked-for-after-they-log-in/

Cheers, and thanks for your work Matías, great app :)

Darian
