### PR TITLE
Untitled

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -127,7 +127,7 @@ class SocialAuthBackend(ModelBackend):
 
         return user
 
-    def username(self, details):
+    def username(self, details, username=None):
         """Return an unique username, if SOCIAL_AUTH_FORCE_RANDOM_USERNAME
         setting is True, then username will be a random USERNAME_MAX_LENGTH
         chars uuid generated hash


### PR DESCRIPTION
changed the signature of 'SocialAuthBackend.username' with a default username set to None, a fix for uninitialized 'username' variable

there is an error on line 147, this is fixed with this patch
