### PR TITLE
Fixed SOCIAL_AUTH_USERNAME_FIXER

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -155,9 +155,10 @@ class SocialAuthBackend(ModelBackend):
 
         while not final_username:
             try:
-                User.objects.get(username=fixer(name))
+                fixed_name = fixer(name)
+                User.objects.get(username=fixed_name)
             except User.DoesNotExist:
-                final_username = name
+                final_username = fixed_name
             else:
                 # User with same username already exists, generate a unique
                 # username for current user using username as base but adding


### PR DESCRIPTION
Before this fix, the output of the `SOCIAL_AUTH_USERNAME_FIXER` function was only used to look up existing users but not for the final username.
