### PR TITLE
Enable the use of south migrations

### DIFF
--- a/social_auth/fields.py
+++ b/social_auth/fields.py
@@ -45,3 +45,10 @@ class JSONField(models.TextField):
     def value_to_string(self, obj):
         """Return value from object converted to string properly"""
         return smart_unicode(self.get_prep_value(self._get_val_from_obj(obj)))
+
+try:
+    import south
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ["^social_auth\.fields\.JSONField"])
+except:
+    pass


### PR DESCRIPTION
social_auth.fields.JSONField needs an introspection rule passed. We can use blank rules because it directly descends from a builtin field and does not add any properties to the parent model.
