### PR TITLE
Stops `auth_process` from modifying request.session[REDIRECT_FIELD_NAME]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ env/
 doc/_build
 example/templates/script*.html
 contrib/tests/test_settings.py
+*#
+.\#*

--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -99,7 +99,7 @@ def auth_process(request, backend, complete_url_name):
     # Check and sanitize a user-defined GET/POST redirect_to field value.
     redirect = sanitize_redirect(request.get_host(),
                                  request.REQUEST.get(REDIRECT_FIELD_NAME))
-    request.session[REDIRECT_FIELD_NAME] = redirect or DEFAULT_REDIRECT
+    #request.session[REDIRECT_FIELD_NAME] = redirect or DEFAULT_REDIRECT
     if backend.uses_redirect:
         return HttpResponseRedirect(backend.auth_url())
     else:


### PR DESCRIPTION
Relevant issue here: https://github.com/omab/django-social-auth/issues/71

auth_process() overwrites the current session[REDIRECT_FIELD_NAME], making it impossible to set the url to redirect to after logging in in a page-specific manner (visiting a certain login page redirects to one page, while visiting another login page redirects to another).
