### PR TITLE
Uncaught exception on backend problem

### DIFF
--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -5,7 +5,6 @@ Notes:
       on third party providers that (if using POST) won't be sending crfs
       token back.
 """
-import logging
 from functools import wraps
 
 from django.conf import settings
@@ -19,9 +18,6 @@ from django.views.decorators.csrf import csrf_exempt
 
 from social_auth.backends import get_backend
 from social_auth.utils import sanitize_redirect
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.ERROR)
 
 def _setting(name, default=''):
     return getattr(settings, name, default)


### PR DESCRIPTION
A couple of days ago, twitter were having some problems with their api and more or less 9/10 times they returned me an empty response here:
https://github.com/omab/django-social-auth/blob/51a67a6f3afcb4f819b1197f30a1056fa8237f1b/social_auth/backends/__init__.py#L595
that would make the following instruction raise a ValueError, and since that wasn't caught anywhere it would result in a 500.
I needed it working fast so I wrote a quick fix ( 8b44511099c65be8be4e ) and today I made it a bit better (more uniform) in a2b44bb65172e781f12f
