### PR TITLE
Don't assume that the association_id (actually, user id) is a number.

### DIFF
--- a/social_auth/urls.py
+++ b/social_auth/urls.py
@@ -12,6 +12,6 @@ urlpatterns = patterns('',
     url(r'^associate/complete/(?P<backend>[^/]+)/$', associate_complete,
         name='socialauth_associate_complete'),
     url(r'^disconnect/(?P<backend>[^/]+)/$', disconnect, name='socialauth_disconnect'),
-    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>\d+)/$', disconnect,
+    url(r'^disconnect/(?P<backend>[^/]+)/(?P<association_id>[^/]+)/$', disconnect,
         name='socialauth_disconnect_individual'),
 )


### PR DESCRIPTION
If I have a user model with an id that is a string, not a number, generating a url to socialauth_disconnect_individual_account fails.  Assuming the backend is twitter and the user id is '4e7026bfaae5715605000001', the exception is:

Caught NoReverseMatch while rendering: Reverse for 'socialauth_disconnect_individual' with arguments '(u'twitter', u'4e7026bfaae5715605000001')' and keyword arguments '{}' not found.

The case where this is happening to me is where the database is mongodb (via django-nonrel), but anybody providing a custom user model with a non-integer primary key could run into a similar problem.
