### PR TITLE
replace "-" with "_"

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -311,7 +311,7 @@ class BaseAuth(object):
         """Return extra argumens needed on auth process, setting is per bancked
         and defined by <backend name in uppercase>_AUTH_EXTRA_ARGUMENTS.
         """
-        name = self.AUTH_BACKEND.name.upper() + '_AUTH_EXTRA_ARGUMENTS'
+        name = self.AUTH_BACKEND.name.upper().replace('-','_') + '_AUTH_EXTRA_ARGUMENTS'
         return getattr(settings, name, {})
 
     @property


### PR DESCRIPTION
Since "Google-Oauth2" is called precisely that and we want to use "GOOGLE_OAUTH2_AUTH_EXTRA_ARGUMENTS = {'access_type': 'offline'}" in our settings we must replace "-" with "_"
