### PR TITLE
Race condition in backend loading - entry point to BACKENDS

### DIFF
--- a/social_auth/context_processors.py
+++ b/social_auth/context_processors.py
@@ -1,4 +1,4 @@
-from social_auth.backends import BACKENDS
+from social_auth.backends import get_backends
 from social_auth.utils import group_backend_by_type
 from social_auth.models import User
 
@@ -34,7 +34,7 @@ def social_auth_by_name_backends(request):
     with a hyphen have the hyphen replaced with an underscore, e.g.
     google-oauth2 becomes google_oauth2 when referenced in templates.
     """
-    keys = BACKENDS.keys()
+    keys = get_backends().keys()
     accounts = dict(zip(keys, [None] * len(keys)))
 
     if isinstance(request.user, User) and request.user.is_authenticated():
@@ -56,7 +56,7 @@ def backends_data(user):
     If user is not authenticated, then first list is empty, and there's no
     difference between the second and third lists.
     """
-    available = BACKENDS.keys()
+    available = get_backends().keys()
     values = {'associated': [],
               'not_associated': available,
               'backends': available}

--- a/social_auth/utils.py
+++ b/social_auth/utils.py
@@ -65,12 +65,12 @@ def group_backend_by_type(items, key=lambda x: x):
 
     # Beware of cyclical imports!
     from social_auth.backends import \
-        BACKENDS, OpenIdAuth, BaseOAuth, BaseOAuth2
+        get_backends, OpenIdAuth, BaseOAuth, BaseOAuth2
 
     result = defaultdict(list)
 
     for item in items:
-        backend = BACKENDS[key(item)]
+        backend = get_backends()[key(item)]
         if issubclass(backend, OpenIdAuth):
             result['openid'].append(item)
         elif issubclass(backend, BaseOAuth2):


### PR DESCRIPTION
I didn't realise other parts of the app referenced `social_auth.backends.BACKENDS`

I've changed these to reference a new function `social_auth.backends.get_backends` which is responsible for populating `BACKENDS` where appropriate.
