### PR TITLE
Foursquare backend fails with "KeyError('lastName')" if user doesn't have a lastName set.

### DIFF
--- a/social_auth/backends/contrib/foursquare.py
+++ b/social_auth/backends/contrib/foursquare.py
@@ -22,7 +22,7 @@ class FoursquareBackend(OAuthBackend):
     def get_user_details(self, response):
         """Return user details from Foursquare account"""
         firstName = response['response']['user']['firstName']
-        lastName = response['response']['user']['lastName']
+        lastName = response['response']['user'].get('lastName', '')
         email = response['response']['user']['contact']['email']
 
         return {USERNAME: firstName + ' ' + lastName,


### PR DESCRIPTION
Just changed the dictionary lookup to .get('lastName', '') to avoid the KeyError. 
