### PR TITLE
FIx for SOCIAL_AUTH_NEW_USER_REDIRECT_URL not working

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -114,7 +114,7 @@ class SocialAuthBackend(ModelBackend):
             # account
             user = social_user.user
             user.social_user = social_user
-            user.is_new = out['is_new']
+            user.is_new = out.get('is_new')
             return user
 
     def pipeline(self, pipeline, request, *args, **kwargs):


### PR DESCRIPTION
Hi matias, a small fix to keep SOCIAL_AUTH_NEW_USER_REDIRECT_URL working, as it was broken a couple commits ago by the pipeline system.
