### PR TITLE
Current 'request' instance should be passed to pipeline methods

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -101,7 +101,6 @@ class SocialAuthBackend(ModelBackend):
         response = kwargs.get('response')
         details = self.get_user_details(response)
         uid = self.get_user_id(details, response)
-
         out = self.pipeline(PIPELINE, backend=self, uid=uid,
                             social_user=None, details=details,
                             is_new=False, *args, **kwargs)
@@ -117,7 +116,7 @@ class SocialAuthBackend(ModelBackend):
             user.is_new = kwargs.get('is_new')
             return user
 
-    def pipeline(self, pipeline, request, *args, **kwargs):
+    def pipeline(self, pipeline, *args, **kwargs):
         """Pipeline"""
         out = kwargs.copy()
 


### PR DESCRIPTION
In earlier commits, we were passing the request instance to all methods in the pipeline. It  can be useful, if you want to, for example, create secondary tables based on session or request attributes etc.
