### PR TITLE
restrict google login by white-listed domains

### DIFF
--- a/doc/backends/google.rst
+++ b/doc/backends/google.rst
@@ -72,7 +72,7 @@ Configurable settings:
 
 - Supply a list of domain strings to be checked. The default (empty list) allows all domains.  If a list is provided and a user attempts to sign in with a Google account that is not in the list, then a ValueError will be raised and the user will be redirected to your login error page::
 
-    WHITE_LISTED_DOMAINS = ['mydomain.com']
+    GOOGLE_WHITE_LISTED_DOMAINS = ['mydomain.com']
 
 
 Orkut

--- a/social_auth/backends/google.py
+++ b/social_auth/backends/google.py
@@ -47,7 +47,7 @@ GOOGLE_OPENID_URL = 'https://www.google.com/accounts/o8/id'
 EXPIRES_NAME = getattr(settings, 'SOCIAL_AUTH_EXPIRATION', 'expires')
 
 # white-listed domains (else accept all)
-WHITE_LISTED_DOMAINS = getattr(settings, 'WHITE_LISTED_DOMAINS', [])
+GOOGLE_WHITE_LISTED_DOMAINS = getattr(settings, 'GOOGLE_WHITE_LISTED_DOMAINS', [])
 
 # Backends
 class GoogleOAuthBackend(OAuthBackend):
@@ -84,7 +84,7 @@ class GoogleBackend(OpenIDBackend):
         is unique enought to flag a single user. Email comes from schema:
         http://axschema.org/contact/email"""
         # only include white-listed domains
-        if WHITE_LISTED_DOMAINS and details['email'].split('@')[1] not in WHITE_LISTED_DOMAINS: 
+        if GOOGLE_WHITE_LISTED_DOMAINS and details['email'].split('@')[1] not in GOOGLE_WHITE_LISTED_DOMAINS: 
             raise ValueError('INVALID DOMAIN')
 
         return details['email']


### PR DESCRIPTION
not sure if this is the best way to do this, but I need to lock-down my app to my company's google app's domain, and this works...
