### PR TITLE
README.rst: Remove reference to south introspection for JSONField

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -662,16 +662,6 @@ Join to django-social-auth_ community on Convore_ and bring any questions or
 suggestions that will improve this app.
 
 
-South_ users should add this rule to enable migrations::
-
-    try:
-        import south
-        from south.modelsinspector import add_introspection_rules
-        add_introspection_rules([], ["^social_auth\.fields\.JSONField"])
-    except:
-        pass
-
-
 If defining a custom user model, do not import social_auth from any models.py
 that would finally import from the models.py that defines your User class or it
 will make your project fail with a recursive import because social_auth uses


### PR DESCRIPTION
Since https://github.com/omab/django-social-auth/pull/57 the code
has been added to fields.py so no need to mention it in the README.
