### PR TITLE
Do not sign OAuth authorization request

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -482,8 +482,10 @@ class ConsumerBasedOAuth(BaseOAuth):
 
     def oauth_authorization_request(self, token):
         """Generate OAuth request to authorize token."""
-        return self.oauth_request(token, self.AUTHORIZATION_URL,
-                                  self.auth_extra_arguments())
+        return OAuthRequest.from_token_and_callback(token=token,
+                                                    callback=self.redirect_uri,
+                                                    http_url=self.AUTHORIZATION_URL,
+                                                    parameters=self.auth_extra_arguments())
 
     def oauth_request(self, token, url, extra_params=None):
         """Generate OAuth request, setups callback url"""


### PR DESCRIPTION
There is no need to sign OAuth authorization URI, see "2.2. Resource Owner Authorization" at http://tools.ietf.org/html/rfc5849#page-10
