### PR TITLE
Re-add the vanilla OpenID backend to the backends collection.

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -687,3 +687,7 @@ def get_backend(name, *args, **kwargs):
             return BACKENDSCACHE[name](*args, **kwargs)
         except KeyError:
             return None
+
+BACKENDS = {
+    'openid': OpenIdAuth
+}


### PR DESCRIPTION
Somewhere between 0.6.1 and 0.6.2 the plain old OpenID backend went missing from the backends collection due to changes in the get_backends function.
Looking for the problem I also noticed that the get_backends function does some unnecessary work by discovering its own BACKENDS cache and adding that to itself (which of course accomplishes exactly nothing). My suggested change is to rename the BACKENDS cache to BACKENDSCACHE to keep it from being discovered, and to add the standard BACKENDS dictionary for the OpenID backend to allow it to be discovered like any other backend.
