### PR TITLE
Python 2.5 compatibility

### DIFF
--- a/social_auth/backends/pipeline/misc.py
+++ b/social_auth/backends/pipeline/misc.py
@@ -11,9 +11,9 @@ def save_status_to_session(request, auth, *args, **kwargs):
 
     try:
         if next_entry:
-            idx = PIPELINE.index(next_entry)
+            idx = list(PIPELINE).index(next_entry)
         else:
-            idx = PIPELINE.index(PIPELINE_ENTRY) + 1
+            idx = list(PIPELINE).index(PIPELINE_ENTRY) + 1
     except ValueError:
         idx = None
 


### PR DESCRIPTION
misc.py in the pipeline module uses the index method on tuples. This method didn't exist until Python 2.6. Would it be all right to use this homemade function instead, to stay compatible with 2.5?
