### PR TITLE
Logged in users would be redirected incorrectly

### DIFF
--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -147,6 +147,9 @@ def complete_process(request, backend, *args, **kwargs):
     if isinstance(user, HttpResponse):
         return user
 
+    if not user and request.user.is_authenticated():
+        return HttpResponseRedirect(redirect_value)
+
     if user:
         if getattr(user, 'is_active', True):
             login(request, user)


### PR DESCRIPTION
Hello,

I am not sure if this is the correct fix or not so I'm sending up for review. If user creation in social auth is turned off but the user is authenticated and the redirect url has been overridden in the session the user would be redirected to the default login url not the overridden one.  Please let know if I did this correctly I understand that its a pretty important area.

Thank you,
  Derrick
