### PR TITLE
OAuth2 backend bails on HTTP 400s in access token requests

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -658,6 +658,11 @@ class BaseOAuth2(BaseOAuth):
 
         try:
             response = simplejson.loads(urlopen(request).read())
+        except HTTPError, e:
+            if e.code == 400:
+                raise AuthCanceled(self)
+            else:
+                raise
         except (ValueError, KeyError):
             raise AuthUnknownError(self)
 


### PR DESCRIPTION
From [the spec section about error responses to access token requests](http://tools.ietf.org/html/draft-ietf-oauth-v2-23#section-4.1.4):

>    The authorization server responds with an HTTP 400 (Bad Request) status code and includes the following parameters with the response

This code is in `BaseOAuth2.auth_complete`:

```
response = simplejson.loads(urlopen(request).read())
```

And because `urllib2.urlopen` will raise `HTTPError` whenever it sees a response that's not 2xx, that causes an unhandled exception.

The code block just below that line tries to handle that case:

```
    if response.get('error'):
        error = response.get('error_description') or response.get('error')
        raise ValueError('OAuth2 authentication failed: %s' % error)
```

But it's never reached.

`ConsumerBasedOAuth.auth_complete` looks like it does something anticipating this status code:

```
    except HTTPError, e:
        if e.code == 400:
            raise AuthCanceled(self)
        else:
            raise
```

I have added a patch that handles 400s in the same way, although I'm not certain if `AuthCanceled` or `AuthFailed` is more appropriate for the OAuth2 scenario.
