### PR TITLE
redirect value transfer to new session.

### DIFF
--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -166,6 +166,8 @@ def complete_process(request, backend, *args, **kwargs):
             # user.social_user is the used UserSocialAuth instance defined
             # in authenticate process
             social_user = user.social_user
+            if redirect_value:
+                request.session[REDIRECT_FIELD_NAME] = redirect_value or DEFAULT_REDIRECT
 
             if setting('SOCIAL_AUTH_SESSION_EXPIRATION', True):
                 # Set session expiration date if present and not disabled by


### PR DESCRIPTION
After session gets trashed all track of  'next' parameter get lost. This was a problem for me since I couldn't create a profile (via NEW_USER_REDIRECT) and then return user to whence he started.

I think that keeping value of next in this session is not too much overhead it is also very practical.
