### PR TITLE
fix bug with dropbox authentication

### DIFF
--- a/social_auth/backends/contrib/dropbox.py
+++ b/social_auth/backends/contrib/dropbox.py
@@ -33,7 +33,7 @@ class DropboxBackend(OAuthBackend):
 
     def get_user_details(self, response):
         """Return user details from Dropbox account"""
-        return {USERNAME: response.get('uid'),
+        return {USERNAME: str(response.get('uid')),
                 'email': response.get('email'),
                 'first_name': response.get('display_name')}
 


### PR DESCRIPTION
it returned username as int, which then caused issues with user registration. Just added a simple int -> str conversion
