### PR TITLE
Make UserSocialAuth optional

### DIFF
--- a/social_auth/admin.py
+++ b/social_auth/admin.py
@@ -1,17 +1,22 @@
 """Admin settings"""
 from django.contrib import admin
 
-from social_auth.models import UserSocialAuth, Nonce, Association
+from social_auth.utils import setting
+from social_auth.models import Nonce, Association
 
 
-class UserSocialAuthOption(admin.ModelAdmin):
-    """Social Auth user options"""
-    list_display = ('id', 'user', 'provider', 'uid')
-    search_fields = ('user__first_name', 'user__last_name', 'user__email')
-    list_filter = ('provider',)
-    raw_id_fields = ('user',)
-    list_select_related = True
+if setting('SOCIAL_AUTH_CREATE_MODEL', True):
+    from social_auth.models import UserSocialAuth
+    
+    class UserSocialAuthOption(admin.ModelAdmin):
+        """Social Auth user options"""
+        list_display = ('id', 'user', 'provider', 'uid')
+        search_fields = ('user__first_name', 'user__last_name', 'user__email')
+        list_filter = ('provider',)
+        raw_id_fields = ('user',)
+        list_select_related = True
 
+    admin.site.register(UserSocialAuth, UserSocialAuthOption)
 
 class NonceOption(admin.ModelAdmin):
     """Nonce options"""
@@ -26,6 +31,5 @@ class AssociationOption(admin.ModelAdmin):
     search_fields = ('server_url',)
 
 
-admin.site.register(UserSocialAuth, UserSocialAuthOption)
 admin.site.register(Nonce, NonceOption)
 admin.site.register(Association, AssociationOption)

--- a/social_auth/models.py
+++ b/social_auth/models.py
@@ -7,59 +7,59 @@ from social_auth.fields import JSONField
 from social_auth.utils import setting
 
 
-# If User class is overridden, it *must* provide the following fields
-# and methods work with django-social-auth:
-#
-#   username   = CharField()
-#   last_login = DateTimeField()
-#   is_active  = BooleanField()
-#   def is_authenticated():
-#       ...
+if setting('SOCIAL_AUTH_CREATE_MODEL', True):
+    # If User class is overridden, it *must* provide the following fields
+    # and methods work with django-social-auth:
+    #
+    #   username   = CharField()
+    #   last_login = DateTimeField()
+    #   is_active  = BooleanField()
+    #   def is_authenticated():
+    #       ...
+    
+    if setting('SOCIAL_AUTH_USER_MODEL'):
+        User = models.get_model(*setting('SOCIAL_AUTH_USER_MODEL').rsplit('.', 1))
+    else:
+        from django.contrib.auth.models import User
+    
+    class UserSocialAuth(models.Model):
+        """Social Auth association model"""
+        user = models.ForeignKey(User, related_name='social_auth')
+        provider = models.CharField(max_length=32)
+        uid = models.CharField(max_length=255)
+        extra_data = JSONField(blank=True)
 
-if setting('SOCIAL_AUTH_USER_MODEL'):
-    User = models.get_model(*setting('SOCIAL_AUTH_USER_MODEL').rsplit('.', 1))
-else:
-    from django.contrib.auth.models import User
+        class Meta:
+            """Meta data"""
+            unique_together = ('provider', 'uid')
 
+        def __unicode__(self):
+            """Return associated user unicode representation"""
+            return unicode(self.user)
 
-class UserSocialAuth(models.Model):
-    """Social Auth association model"""
-    user = models.ForeignKey(User, related_name='social_auth')
-    provider = models.CharField(max_length=32)
-    uid = models.CharField(max_length=255)
-    extra_data = JSONField(blank=True)
+        @property
+        def tokens(self):
+            """Return access_token stored in extra_data or None"""
+            # Make import here to avoid recursive imports :-/
+            from social_auth.backends import get_backends
+            backend = get_backends().get(self.provider)
+            if backend:
+                return backend.AUTH_BACKEND.tokens(self)
+            else:
+                return {}
 
-    class Meta:
-        """Meta data"""
-        unique_together = ('provider', 'uid')
-
-    def __unicode__(self):
-        """Return associated user unicode representation"""
-        return unicode(self.user)
-
-    @property
-    def tokens(self):
-        """Return access_token stored in extra_data or None"""
-        # Make import here to avoid recursive imports :-/
-        from social_auth.backends import get_backends
-        backend = get_backends().get(self.provider)
-        if backend:
-            return backend.AUTH_BACKEND.tokens(self)
-        else:
-            return {}
-
-    def expiration_delta(self):
-        """Return saved session expiration seconds if any. Is returned in
-        the form of a timedelta data type. None is returned if there's no
-        value stored or it's malformed.
-        """
-        if self.extra_data:
-            name = setting('SOCIAL_AUTH_EXPIRATION', 'expires')
-            try:
-                return timedelta(seconds=int(self.extra_data.get(name)))
-            except (ValueError, TypeError):
-                pass
-        return None
+        def expiration_delta(self):
+            """Return saved session expiration seconds if any. Is returned in
+            the form of a timedelta data type. None is returned if there's no
+            value stored or it's malformed.
+            """
+            if self.extra_data:
+                name = setting('SOCIAL_AUTH_EXPIRATION', 'expires')
+                try:
+                    return timedelta(seconds=int(self.extra_data.get(name)))
+                except (ValueError, TypeError):
+                    pass
+            return None
 
 
 class Nonce(models.Model):

--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -170,7 +170,7 @@ def complete_process(request, backend, *args, **kwargs):
                 request.session[REDIRECT_FIELD_NAME] = redirect_value or \
                                                        DEFAULT_REDIRECT
 
-            if setting('SOCIAL_AUTH_SESSION_EXPIRATION', True):
+            if setting('SOCIAL_AUTH_SESSION_EXPIRATION', True) and hasattr(social_user, 'expiration_delta'):
                 # Set session expiration date if present and not disabled by
                 # setting. Use last social-auth instance for current provider,
                 # users can associate several accounts with a same provider.
@@ -180,7 +180,7 @@ def complete_process(request, backend, *args, **kwargs):
             # store last login backend name in session
             key = setting('SOCIAL_AUTH_LAST_LOGIN',
                           'social_auth_last_login_backend')
-            request.session[key] = social_user.provider
+            request.session[key] = backend.AUTH_BACKEND.name
 
             # Remove possible redirect URL from session, if this is a new
             # account, send him to the new-users-page if defined.


### PR DESCRIPTION
`UserSocialAuth` could be made optional without any problems.

In my project, I had something similar to `UserSocialAuth` which required custom pipelines in order to get/create my auth objects. 

Your djangoapp is so good that it was easy enough to remove the dependency on `UserSocialAuth`.
In my case I couldn't use the defaults pipelines but with my custom ones everything worked like a charm.

I worked on a basic version but there might be side effects that I didn't consider so please double check first.
I introduced a new item in settings called `SOCIAL_AUTH_CREATE_MODEL` which, if False, doesn't create the `UserSocialAuth` table and the related `ModelAdmin`.
