### PR TITLE
Code assumes that details.get(USERNAME) will return a string. 

### DIFF
--- a/social_auth/backends/pipeline/user.py
+++ b/social_auth/backends/pipeline/user.py
@@ -31,7 +31,7 @@ def get_username(details, user=None, user_exists=simple_user_exists,
     if setting('SOCIAL_AUTH_FORCE_RANDOM_USERNAME'):
         username = uuid4().get_hex()
     elif details.get(USERNAME):
-        username = details[USERNAME]
+        username = unicode(details[USERNAME])
     elif setting('SOCIAL_AUTH_DEFAULT_USERNAME'):
         username = setting('SOCIAL_AUTH_DEFAULT_USERNAME')
         if callable(username):


### PR DESCRIPTION
That's not the case with the dropbox backend (which returns an int) and possibly others. Without casting to a string we'll get an error on line 45. The other alternative is to call username_fixer prior to the short_username change, which could do the cast for backends that require it.
