### PR TITLE
the username paramter for vkontakte backend

### DIFF
--- a/social_auth/backends/contrib/vkontakte.py
+++ b/social_auth/backends/contrib/vkontakte.py
@@ -32,8 +32,7 @@ class VkontakteBackend(OAuthBackend):
     def get_user_details(self, response):
         """Return user details from Vkontakte account"""
         print response
-        return {USERNAME: response.get('nickname') or \
-                          response.get('screen_name'),
+        return {USERNAME: response.get('screen_name'),
                 'email':  '',
                 'first_name': response.get('first_name'),
                 'last_name': response.get('last_name')}


### PR DESCRIPTION
I think that the username parameter for vkontakte backend should be taken from screen_name only. That's because the nickname parameter is not unique. screen_name is better. Even if user doesn't set his short name this parameter will return 'id'+ uid
