### PR TITLE
extra_data.update() was raising a TypeError because the field is created blank and is considered null by the JSONField

### DIFF
--- a/social_auth/models.py
+++ b/social_auth/models.py
@@ -27,7 +27,7 @@ class UserSocialAuth(models.Model):
     user = models.ForeignKey(User, related_name='social_auth')
     provider = models.CharField(max_length=32)
     uid = models.CharField(max_length=255)
-    extra_data = JSONField(blank=True)
+    extra_data = JSONField(default='{}')
 
     class Meta:
         """Meta data"""


### PR DESCRIPTION
Prepopulates UserSocialAuth instance with an empty dictionary to allow the calling of extra_data.update() without raising a TypeError because the field was considered None when null.

I'm not sure if this is the best approach, but it's working now.
