### PR TITLE
Facebook backend bug : username is never set

### DIFF
--- a/social_auth/backends/facebook.py
+++ b/social_auth/backends/facebook.py
@@ -45,7 +45,7 @@ class FacebookBackend(OAuthBackend):
 
     def get_user_details(self, response):
         """Return user details from Facebook account"""
-        return {USERNAME: response.get('username'),
+        return {USERNAME: response.get('name'),
                 'email': response.get('email', ''),
                 'fullname': response.get('name', ''),
                 'first_name': response.get('first_name', ''),


### PR DESCRIPTION
facebook backend : response.get('username') doesn't exist, replaced by 'name'
