### PR TITLE
Support for Google OAuth 2.0 immutable identifier

### DIFF
--- a/social_auth/backends/google.py
+++ b/social_auth/backends/google.py
@@ -74,6 +74,13 @@ class GoogleOAuth2Backend(GoogleOAuthBackend):
         ('expires_in', setting('SOCIAL_AUTH_EXPIRATION', 'expires'))
     ]
 
+    def get_user_id(self, details, response):
+        """Use google email or id as unique id"""
+        user_id = super(GoogleOAuth2Backend, self).get_user_id(details, response)
+        if setting('GOOGLE_OAUTH2_USE_UNIQUE_USER_ID', False):
+            return response['id']
+        return user_id
+
     def get_user_details(self, response):
         email = response['email']
         return {USERNAME: email.split('@', 1)[0],


### PR DESCRIPTION
Hello everyone,

I added support for the ID fields in the profile information available to the Google OAuth 2.0 backend.
See [here](https://developers.google.com/accounts/docs/OAuth2Login#userinfocall) for more information regarding the profile information.

As this would result in a somewhat backwards incompatible change if SOCIAL_AUTH_ASSOCIATE_BY_MAIL is False, I added a new setting called GOOGLE_OAUTH2_USE_UNIQUE_USER_ID which defaults to False and needs to be set to True in order to use the user ID as uid in Social Auth.

This change avoids problems with non-GMail Google Accounts changing their email address.

I also fixed a small typo in a function comment.

Best regards
Marc
