### PR TITLE
Updated documentation for GOOGLE_OAUTH2_USE_UNIQUE_USER_ID

### DIFF
--- a/doc/backends/google.rst
+++ b/doc/backends/google.rst
@@ -70,6 +70,11 @@ To enable OAuth2 support:
 
       GOOGLE_OAUTH_EXTRA_SCOPE = [...]
 
+- optional support for static and unique Google Profile ID identifiers instead of
+  using the e-mail address for account association can be enabled with::
+
+      GOOGLE_OAUTH2_USE_UNIQUE_USER_ID = True
+
 Check which applications can be included in their `Google Data Protocol Directory`_
 
 


### PR DESCRIPTION
Updated the Google OAuth 2.0 backend documentation to include information about GOOGLE_OAUTH2_USE_UNIQUE_USER_ID.
