### PR TITLE
Bitbucket multiple email bug.

### DIFF
--- a/social_auth/backends/contrib/bitbucket.py
+++ b/social_auth/backends/contrib/bitbucket.py
@@ -85,7 +85,13 @@ class BitbucketAuth(ConsumerBasedOAuth):
         request = self.oauth_request(access_token, url)
         response = self.fetch_response(request)
         try:
-            email = simplejson.loads(response)[0]['email']
+            # Then retrieve the user's primary email address or the top email
+            email_addresses = simplejson.loads(response)
+            for email_address in reversed(email_addresses):
+                if email_address['active']:
+                    email = email_address['email']
+                    if email_address['primary']:
+                        break
             # Then return the user data using a normal GET with the
             # BITBUCKET_USER_DATA_URL and the user's email
             response = urlopen(BITBUCKET_USER_DATA_URL + email)


### PR DESCRIPTION
Found a bug where if a bitbucket user has multiple email addresses associated with their bitbucket account, it would currently take the top one which was not necessarily their active primary address.

Now takes their active primary email address and if one can't be found (I assume this is impossible but thought I would put it in just in case) will retrieve the first returned active email address.
