### PR TITLE
Canvas app login is broken

### DIFF
--- a/social_auth/backends/facebook.py
+++ b/social_auth/backends/facebook.py
@@ -135,7 +135,7 @@ class FacebookAuth(BaseOAuth2):
             # expires will not be part of response if offline access
             # premission was requested
             if expires:
-                data['expires'] = response['expires'][0]
+                data['expires'] = expires
 
             kwargs.update({'auth': self,
                            'response': data,


### PR DESCRIPTION
The correct value for expires is calculated above depending on whether it is a canvas app or facebook connect but it is not used. Instead, it is assumed that app is facebook connect.
