### PR TITLE
facebook username field not used

### DIFF
--- a/social_auth/backends/facebook.py
+++ b/social_auth/backends/facebook.py
@@ -45,7 +45,7 @@ class FacebookBackend(OAuthBackend):
 
     def get_user_details(self, response):
         """Return user details from Facebook account"""
-        return {USERNAME: response.get('name'),
+        return {USERNAME: response.get('username', response.get('name')),
                 'email': response.get('email', ''),
                 'fullname': response.get('name', ''),
                 'first_name': response.get('first_name', ''),


### PR DESCRIPTION
When grabbing the additional data from the facebook provider, try to use the `username` field if available. Current code grabs `name` field which is nothing more but a concatenation of `first_name` and `last_name`
