### PR TITLE
IntegrityError Fix for updating extra_data when new user account

### DIFF
--- a/social_auth/backends/pipeline/social.py
+++ b/social_auth/backends/pipeline/social.py
@@ -22,10 +22,9 @@ def social_auth_user(backend, uid, user=None, *args, **kwargs):
 
     if social_user:
         if user and social_user.user != user:
-            raise AuthException(backend,
-                ugettext('This %(provider)s account is already in use.') % {
-                    'provider': backend.name
-                })
+            raise AuthException(backend, ugettext('This %(provider)s account already in use.') % {
+                'provider':backend.name,
+            })
         elif not user:
             user = social_user.user
     return {'social_user': social_user, 'user': user}
@@ -59,5 +58,8 @@ def load_extra_data(backend, details, response, social_user, uid, user,
     if setting('SOCIAL_AUTH_EXTRA_DATA', True):
         extra_data = backend.extra_data(user, uid, response, details)
         if extra_data and social_user.extra_data != extra_data:
-            social_user.extra_data.update(extra_data)
+            if social_user.extra_data:
+                social_user.extra_data.update(extra_data)
+            else:
+                social_user.extra_data = extra_data
             social_user.save()


### PR DESCRIPTION
extra_data is only updated instead of overwritten it was changed
here:
https://github.com/omab/django-social-auth/commit/cafe06eef838a7ee54312e
c42a84a03ade835c0d. However this results in an Integrity error if a new
account is being created for the first time. This fixes that.

Originally started with this bug: https://github.com/omab/django-social-auth/issues/299
