### PR TITLE
Adds convenience querystring for login redirects

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -140,6 +140,12 @@ Configuration
   ``social_auth_backends`` and ``social_auth_by_type_backends`` don't play nice
   together.
 
+  **Also:** For man in the middle redirects (ie authenticating via a login required decorator), a convenince query string can be added to your context for templates.  On your login options page: ``<a href={{% url socialauth_begin 'twitter' %}?{{ redirect_querystring }}">`` allows for a continuous login.  Useful if multiple login options are presented.  
+
+	To enable, add the following Context Processor::
+		
+		'social_auth.context_processors.social_auth_login_redirect',
+
 - Sync database to create needed models::
 
     ./manage.py syncdb

--- a/social_auth/context_processors.py
+++ b/social_auth/context_processors.py
@@ -2,6 +2,8 @@ from social_auth.backends import get_backends
 from social_auth.utils import group_backend_by_type
 from social_auth.models import User
 
+from django.contrib.auth import REDIRECT_FIELD_NAME as auth_redirect
+from django.conf import settings
 
 # Note: social_auth_backends, social_auth_by_type_backends and
 #       social_auth_by_name_backends don't play nice together.
@@ -71,3 +73,17 @@ def backends_data(user):
         values['associated'] = associated
         values['not_associated'] = not_associated
     return values
+ 
+def social_auth_login_redirect(request):
+    """Load current redirect to context
+    Provides access to the redirect variable as named in the settings file
+    Assumes that the redirect field name is set in the settings file
+		"""
+    redirect_name = getattr(settings, 'REDIRECT_FIELD_NAME', auth_redirect)
+    redirect_value = request.REQUEST.get(redirect_name, '')
+    context = {
+        'REDIRECT_FIELD_NAME' : redirect_name, 
+        'REDIRECT_FIELD_VALUE' : redirect_value,
+        'redirect_querystring' : redirect_name + '=' + redirect_value
+    }
+    return context


### PR DESCRIPTION
Adds an optional context_processor to provide the redirect querystring for redirected login pages. Useful for multiple authentication methods.  
