### PR TITLE
VKontakteBackend starts from two capital letters now instead of one.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Configuration
         'social_auth.backends.contrib.dropbox.DropboxBackend',
         'social_auth.backends.contrib.flickr.FlickrBackend',
         'social_auth.backends.contrib.instagram.InstagramBackend',
-        'social_auth.backends.contrib.vkontakte.VkontakteBackend',
+        'social_auth.backends.contrib.vkontakte.VKontakteBackend',
         'social_auth.backends.contrib.skyrock.SkyrockBackend',
         'social_auth.backends.contrib.yahoo.YahooOAuthBackend',        
         'social_auth.backends.OpenIDBackend',


### PR DESCRIPTION
Killed 30 minutes now just to find out why "  'module' object has no attribute 'VkontakteBackend'  "
