### PR TITLE
 Fixed bug in flickr.py. Allowing users to change perms setting

### DIFF
--- a/social_auth/backends/contrib/flickr.py
+++ b/social_auth/backends/contrib/flickr.py
@@ -83,7 +83,8 @@ class FlickrAuth(ConsumerBasedOAuth):
 
     def auth_extra_arguments(self):
         params = super(FlickrAuth, self).auth_extra_arguments() or {}
-        params['perms'] = 'read'
+        if not 'perms' in params:
+            params['perms'] = 'read'
         return params
 
 


### PR DESCRIPTION
 Fixed bug where FLICKR_AUTH_EXTRA_ARGUMENTS's `perms` configuration is ignored by the backend.
