### PR TITLE
UserSocialAuthMixin.create_user get's AttributeError with mongoengine

### DIFF
--- a/social_auth/db/mongoengine_models.py
+++ b/social_auth/db/mongoengine_models.py
@@ -13,6 +13,7 @@ from social_auth.db.base import UserSocialAuthMixin, AssociationMixin, \
 
 class UserSocialAuth(Document, UserSocialAuthMixin):
     """Social Auth association model"""
+    User = User
     user = ReferenceField(User)
     provider = StringField(max_length=32)
     uid = StringField(max_length=255, unique_with='provider')


### PR DESCRIPTION
The Django ORM UserSocialAuthMixin got the User attribute but the mongoengine version didn't. So during create_user an AttributeError is raised (NoneType doesn't have objects). Simple fix included.
