### PR TITLE
Provide a more specific exception type for duplicate social account usage

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -284,6 +284,9 @@ Configuration
     AuthMissingParameter    - A needed parameter to continue the process was
                               missing, usually raised by the services that
                               need some POST data like myOpenID
+    AuthAlreadyAssociated   - A different user has already associated
+                              the social account that the current user
+                              is trying to associate. 
 
   These are a subclass of ``ValueError`` to keep backward compatibility.
 

--- a/social_auth/backends/exceptions.py
+++ b/social_auth/backends/exceptions.py
@@ -71,3 +71,9 @@ class AuthStateForbidden(AuthException):
     """State parameter is incorrect."""
     def __unicode__(self):
         return u'Wrong state parameter given.'
+
+
+class AuthAlreadyAssociated(AuthException):
+    """A different user has already associated the target social account"""
+    pass
+

--- a/social_auth/backends/pipeline/social.py
+++ b/social_auth/backends/pipeline/social.py
@@ -1,5 +1,5 @@
 from social_auth.models import UserSocialAuth, SOCIAL_AUTH_MODELS_MODULE
-from social_auth.backends.exceptions import AuthException
+from social_auth.backends.exceptions import AuthAlreadyAssociated
 from django.utils.translation import ugettext
 
 
@@ -7,13 +7,13 @@ def social_auth_user(backend, uid, user=None, *args, **kwargs):
     """Return UserSocialAuth account for backend/uid pair or None if it
     doesn't exists.
 
-    Raise AuthException if UserSocialAuth entry belongs to another user.
+    Raise AuthAlreadyAssociated if UserSocialAuth entry belongs to another user.
     """
     social_user = UserSocialAuth.get_social_auth(backend.name, uid)
     if social_user:
         if user and social_user.user != user:
             msg = ugettext('This %(provider)s account already in use.')
-            raise AuthException(backend, msg % {'provider': backend.name})
+            raise AuthAlreadyAssociated(backend, msg % {'provider': backend.name})
         elif not user:
             user = social_user.user
     return {'social_user': social_user, 'user': user}
@@ -50,3 +50,4 @@ def load_extra_data(backend, details, response, social_user, uid, user,
         else:
             social_user.extra_data = extra_data
         social_user.save()
+


### PR DESCRIPTION
Defined AuthAlreadyAssociated for when a 2nd user tries to associate a particular social account (e.g., twitter handle).

I also may add a configurable middleware for handling this and other specific exceptions pending the disucssion on issue #428 (whether or not the middleware is needed or the functionality is covered by social_auth.utils.log_exceptions_to_messages.
