### PR TITLE
Add in support for grabbing linkedin emails

### DIFF
--- a/social_auth/backends/contrib/linkedin.py
+++ b/social_auth/backends/contrib/linkedin.py
@@ -34,11 +34,12 @@ class LinkedinBackend(OAuthBackend):
     def get_user_details(self, response):
         """Return user details from Linkedin account"""
         first_name, last_name = response['first-name'], response['last-name']
+        email = response.get('email-address', '')
         return {USERNAME: first_name + last_name,
                 'fullname': first_name + ' ' + last_name,
                 'first_name': first_name,
                 'last_name': last_name,
-                'email': ''}
+                'email': email}
 
 
 class LinkedinAuth(ConsumerBasedOAuth):


### PR DESCRIPTION
Linkedin as of today allows developers to grab the user's email address 
along with a bunch of other attributes as explained in their blog post here: 
https://developer.linkedin.com/blog/making-it-easier-you-develop-linkedin

They are using a oauth2-like "scope" parameter to allow applications to 
request extended permissions, which I was able to hook into by adding
LINKEDIN_REQUEST_TOKEN_EXTRA_ARGUMENTS = {'scope':'r_emailaddress r_contactinfo}'}
to settings.py. 

Note: if you have an old linkedin api key, you have to generate a new one 
to use the new goodies, or wait until they provide a migration path.
