### PR TITLE
Allow exception processors to redirect to arbitrary URLs

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -268,7 +268,9 @@ Configuration
 
   The function parameters are ``request`` holding the current request object,
   ``backend`` with the current backend and ``err`` which is the exception
-  instance.
+  instance. If the function returns a URL, the user will be redirected to it.
+  Otherwise, they will be redirected to the backend's error URL, or
+  ``LOGIN_ERROR_URL``.
 
   Recently this set of exceptions were introduce to describe the situations
   a bit more than the old ``ValueError`` usually raised::

--- a/social_auth/decorators.py
+++ b/social_auth/decorators.py
@@ -44,6 +44,7 @@ def dsa_view(redirect_name=None):
                     'request': request
                 })
 
+                url = None
                 mod, func_name = PROCESS_EXCEPTIONS.rsplit('.', 1)
                 try:
                     process = getattr(import_module(mod), func_name,
@@ -51,10 +52,11 @@ def dsa_view(redirect_name=None):
                 except ImportError:
                     pass
                 else:
-                    process(request, backend, e)
+                    url = process(request, backend, e)
 
-                url = backend_setting(backend, 'SOCIAL_AUTH_BACKEND_ERROR_URL',
-                                      LOGIN_ERROR_URL)
+                if not url:
+                    url = backend_setting(backend, 'SOCIAL_AUTH_BACKEND_ERROR_URL',
+                                        LOGIN_ERROR_URL)
                 return HttpResponseRedirect(url)
         return wrapper
     return dec


### PR DESCRIPTION
I've found configuring redirects via settings.py to be pretty restrictive, so I added the ability to redirect to arbitrary URLs from exception processors. This allows you to send the user to different pages depending on the error and user state by returning a URL from the exception processor function.
