### PR TITLE
Added new permissions requesting to Linkedin Backend

### DIFF
--- a/doc/backends/linkedin.rst
+++ b/doc/backends/linkedin.rst
@@ -11,5 +11,15 @@ way the values will be stored in ``UserSocialAuth.extra_data`` field.
 
 By default ``id``, ``first-name`` and ``last-name`` are requested and stored.
 
+If you want to request a user's email address, you'll need specify that your app needs access to the email address using the ``r_emailaddress`` scope parameter. Also note that until they figure out a migration plan, they require new api keys from the LinkedIn API (Issued after August 6th, 2012).
+
+LinkedIn emulates the scope parameter of oauth2 to specify user privileges. Check here for `scope possibilities`_ if you need more than just the basic profile.
+
+These are declared as a list by defining this setting::
+
+    LINKEDIN_SCOPE = ['r_basicprofile', ...]
+    
 
 .. _LinkedIn fields selectors: http://developer.linkedin.com/docs/DOC-1014
+.. _scope possibilities: https://developer.linkedin.com/documents/authentication#granting
+


### PR DESCRIPTION
LInkedIn implemented the oauth2 scope concept into their oauth1 system. It's a bit funky, but this seems to work and be backwards compatible with earlier versions of the API which should just ignore the extra url params. I tried specifying scope within the call params vs the URL, and it didn't work for some reason as params. I think it has something to do with the URL encoding.

I added docs on how to specify scope withing the settings file.
