### PR TITLE
Changed associate_complete to check redirect_value first

### DIFF
--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -51,9 +51,9 @@ def associate_complete(request, backend, *args, **kwargs):
     elif isinstance(user, HttpResponse):
         return user
     else:
-        url = backend_setting(backend,
+        url = redirect_value or \
+              backend_setting(backend,
                               'SOCIAL_AUTH_NEW_ASSOCIATION_REDIRECT_URL') or \
-              redirect_value or \
               DEFAULT_REDIRECT
     return HttpResponseRedirect(url)
 


### PR DESCRIPTION
There's an issue already about the `redirect_value` (`next`) parameter being ignored, this changes that behaviour.

Without this change you have to remove `SOCIAL_AUTH_NEW_ASSOCIATION_REDIRECT_URL` from settings.
