### PR TITLE
Support OpenID PAPE max_auth_age

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -493,10 +493,15 @@ class OpenIdAuth(BaseAuth):
             fetch_request = sreg.SRegRequest(optional=dict(SREG_ATTR).keys())
         openid_request.addExtension(fetch_request)
 
-        # Add PAPE Extension for max_auth_age
-        pape_request = pape.Request(max_auth_age=0)
-        openid_request.addExtension(pape_request)
-
+        # Add PAPE Extension for max_auth_age, if configured
+        if setting('SOCIAL_AUTH_OPENID_PAPE_MAX_AUTH_AGE') is not None:
+            try:
+                max_age = int(setting('SOCIAL_AUTH_OPENID_PAPE_MAX_AUTH_AGE'))
+                pape_request = pape.Request(max_auth_age=max_age)
+                openid_request.addExtension(pape_request)
+            except:
+                # ignore misconfiguration
+                pass
 
         return openid_request
 


### PR DESCRIPTION
Especially Google login with OpenID supports the PAPE extension (so does python-openid) with the max_auth_age parameter, which specifies the amount of seconds until the OpenID server will ask again for a password.
It often makes sense to set this to 0, thus forcing new password entry every time login is tried.

Can be configured in settings with
SOCIAL_AUTH_OPENID_PAPE_MAX_AUTH_AGE=0

if not present, PAPE extension will not be added to OpenID request (then, exactly same behavior as before).
