### PR TITLE
SocialAuthBackend only needs to authenticated

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -19,7 +19,6 @@ from openid.extensions import sreg, ax, pape
 from oauth2 import Consumer as OAuthConsumer, Token, Request as OAuthRequest
 
 from django.contrib.auth import authenticate
-from django.contrib.auth.backends import ModelBackend
 from django.utils import simplejson
 from django.utils.importlib import import_module
 
@@ -78,7 +77,7 @@ PIPELINE = setting('SOCIAL_AUTH_PIPELINE', (
            ))
 
 
-class SocialAuthBackend(ModelBackend):
+class SocialAuthBackend(object):
     """A django.contrib.auth backend that authenticates the user based on
     a authentication provider response"""
     name = ''  # provider name, it's stored in database


### PR DESCRIPTION
In attempting to get this library to work with a permissions backend it kept failing because SociaAuthBackend was inheriting from the django.contrib.auth.backends.ModelBackend.  The default Django AuthBackend assumes SQL.  Since this application does both SQL and Mongo it should not make the same assumptions.

The SocialAuthBackend only needs to implement authenticate, since it only does authentication.  Since it defines authenticate as a method, it's fine to inherit from object rather than the django model auth backend. 

I've tested this change against a few backends for SQL and Mongo and not had any issues.  Since tests are manual though, I recommend doing some as well. 

for reference

https://docs.djangoproject.com/en/dev/topics/auth/#authentication-backends
