### PR TITLE
#489 Extend permissions only for a few users

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -770,6 +770,8 @@ class BaseOAuth2(BaseOAuth):
         scope = self.DEFAULT_SCOPE or []
         if self.SCOPE_VAR_NAME:
             scope = scope + setting(self.SCOPE_VAR_NAME, [])
+        if self.data.has_key('add_scopes'):
+            scope = scope + self.data['add_scopes'].split(',')
         return scope
 
 


### PR DESCRIPTION
This change lets the application have different authorization requirements in different situations, so that I can only request some authorizations from users that need it.
