### PR TITLE
Add email, fix session setup

### DIFF
--- a/social_auth/backends/contrib/shopify.py
+++ b/social_auth/backends/contrib/shopify.py
@@ -33,8 +33,7 @@ class ShopifyBackend(OAuthBackend):
         """Use the shopify store name as the username"""
         return {
             USERNAME: unicode(response.get('shop', '')\
-                                      .replace('.myshopify.com', '')),
-            'email': "no_email_set@example.com"
+                                      .replace('.myshopify.com', ''))
         }
 
     def get_user_id(self, details, response):

--- a/social_auth/backends/pipeline/user.py
+++ b/social_auth/backends/pipeline/user.py
@@ -44,7 +44,7 @@ def create_user(backend, details, response, uid, username, user=None, *args,
     if not username:
         return None
 
-    args = {'username': username}
+    args = {'username': username, 'email': ''}
     if details.get('email'):
         args['email'] = details['email']
 


### PR DESCRIPTION
- Return a temporary email address for the user, or no account will be created. (No email is returned from shopify)
-  The session must be setup before each call with the app key and secret
