### PR TITLE
Add support for additional PAPE settings on OpenID request

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -493,15 +493,26 @@ class OpenIdAuth(BaseAuth):
             fetch_request = sreg.SRegRequest(optional=dict(SREG_ATTR).keys())
         openid_request.addExtension(fetch_request)
 
-        # Add PAPE Extension for max_auth_age, if configured
+        # Add PAPE Extension for if configured
+        preferred_policies = setting(
+            'SOCIAL_AUTH_OPENID_PAPE_PREFERRED_AUTH_POLICIES')
+        preferred_level_types = setting(
+            'SOCIAL_AUTH_OPENID_PAPE_PREFERRED_AUTH_LEVEL_TYPES')
         max_age = setting('SOCIAL_AUTH_OPENID_PAPE_MAX_AUTH_AGE')
         if max_age is not None:
             try:
-                openid_request.addExtension(
-                    pape.Request(max_auth_age=int(max_age))
-                )
+                max_age = int(max_age)
             except (ValueError, TypeError):
-                pass
+                max_age = None
+
+        if (max_age is not None or preferred_policies is not None
+            or preferred_level_types is not None):
+            pape_request = pape.Request(
+                preferred_auth_policies=preferred_policies,
+                max_auth_age=max_age,
+                preferred_auth_level_types=preferred_level_types
+            )
+            openid_request.addExtension(pape_request)
 
         return openid_request
 


### PR DESCRIPTION
The initial pull request (https://github.com/omab/django-social-auth/pull/469) to add the Provider Authentication Policy Extension (PAPE) to the library only supported the max_auth_age parameter on the OpenID request. There are additional parameters on the request (https://github.com/openid/python-openid/blob/master/openid/extensions/draft/pape5.py#L113) that should also be supported as well. 

This pull request will attempt to pull each of the three parameters from settings. If any one of them is present the extension will be added onto the OpenID request. This should be passive to any current consumers that only use the max_auth_age as None is the default input for the other two parameters. Looking at the spec http://openid.net/specs/openid-provider-authentication-policy-extension-1_0.html#anchor8 it seems all these parameters that are supported are optional except preferred_auth_policies which does accept zero entries which the python_openid library will handle by passing [] for that setting if it's None.
