### PR TITLE
associate_user returns an empty dictionary if user is None

### DIFF
--- a/social_auth/backends/pipeline/social.py
+++ b/social_auth/backends/pipeline/social.py
@@ -26,6 +26,9 @@ def associate_user(backend, user, uid, social_user=None, *args, **kwargs):
     """Associate user social account with user instance."""
     if social_user:
         return None
+    
+    if not user:
+        return {}
 
     try:
         social = UserSocialAuth.create_social_auth(user, uid, backend.name)


### PR DESCRIPTION
In the case where .create_user pipeline is omitted user == None, therefore error is raised.
This fix just returns an empty dictionary if user is None.
