### PR TITLE
Update social_auth/backends/pipeline/user.py

### DIFF
--- a/social_auth/backends/pipeline/user.py
+++ b/social_auth/backends/pipeline/user.py
@@ -54,38 +54,41 @@ def create_user(backend, details, response, uid, username, user=None, *args,
 def update_user_details(backend, details, response, user, is_new=False, *args,
                         **kwargs):
     """Update user details using data from provider."""
-    changed = False  # flag to track changes
+    try:
+        changed = False  # flag to track changes
+    
+        for name, value in details.iteritems():
+            # do not update username, it was already generated
+            # do not update configured fields if user already existed
+            if name in (USERNAME, 'id', 'pk') or (not is_new and
+                name in setting('SOCIAL_AUTH_PROTECTED_USER_FIELDS', [])):
+                continue
+            if value and value != getattr(user, name, None):
+                setattr(user, name, value)
+                changed = True
 
-    for name, value in details.iteritems():
-        # do not update username, it was already generated
-        # do not update configured fields if user already existed
-        if name in (USERNAME, 'id', 'pk') or (not is_new and
-            name in setting('SOCIAL_AUTH_PROTECTED_USER_FIELDS', [])):
-            continue
-        if value and value != getattr(user, name, None):
-            setattr(user, name, value)
-            changed = True
+        # Fire a pre-update signal sending current backend instance,
+        # user instance (created or retrieved from database), service
+        # response and processed details.
+        #
+        # Also fire socialauth_registered signal for newly registered
+        # users.
+        #
+        # Signal handlers must return True or False to signal instance
+        # changes. Send method returns a list of tuples with receiver
+        # and it's response.
+        signal_response = lambda (receiver, response): response
+        signal_kwargs = {'sender': backend.__class__, 'user': user,
+                         'response': response, 'details': details}
 
-    # Fire a pre-update signal sending current backend instance,
-    # user instance (created or retrieved from database), service
-    # response and processed details.
-    #
-    # Also fire socialauth_registered signal for newly registered
-    # users.
-    #
-    # Signal handlers must return True or False to signal instance
-    # changes. Send method returns a list of tuples with receiver
-    # and it's response.
-    signal_response = lambda (receiver, response): response
-    signal_kwargs = {'sender': backend.__class__, 'user': user,
-                     'response': response, 'details': details}
+        changed |= any(filter(signal_response, pre_update.send(**signal_kwargs)))
 
-    changed |= any(filter(signal_response, pre_update.send(**signal_kwargs)))
+        # Fire socialauth_registered signal on new user registration
+        if is_new:
+            changed |= any(filter(signal_response,
+                                  socialauth_registered.send(**signal_kwargs)))
 
-    # Fire socialauth_registered signal on new user registration
-    if is_new:
-        changed |= any(filter(signal_response,
-                              socialauth_registered.send(**signal_kwargs)))
-
-    if changed:
-        user.save()
+        if changed:
+            user.save()
+    except:
+        pass


### PR DESCRIPTION
Related to my previous pull request:
When .create_user pipeline is omitted update_user_details attempts to evaluate a None object when user == None.
Function returns None which subsequently redirects to the appropriate login-error page.
