### PR TITLE
Unable to use reverse_lazy in SOCIAL_AUTH_LOGIN_REDIRECT_URL variable 

### DIFF
--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -16,8 +16,8 @@ from social_auth.utils import sanitize_redirect, setting, \
 from social_auth.decorators import dsa_view
 
 
-DEFAULT_REDIRECT = setting('SOCIAL_AUTH_LOGIN_REDIRECT_URL') or \
-                   setting('LOGIN_REDIRECT_URL')
+DEFAULT_REDIRECT = setting('SOCIAL_AUTH_LOGIN_REDIRECT_URL',
+                           setting('LOGIN_REDIRECT_URL'))
 LOGIN_ERROR_URL = setting('LOGIN_ERROR_URL', setting('LOGIN_URL'))
 PIPELINE_KEY = setting('SOCIAL_AUTH_PARTIAL_PIPELINE_KEY', 'partial_pipeline')
 


### PR DESCRIPTION
Using reverse_lazy in SOCIAL_AUTH_LOGIN_REDIRECT_URL raises an exception::

```
ImproperlyConfigured: The included urlconf social_auth.urls doesn't have any patterns in it
```

The problem is the following line in social_auth.views::

```
 DEFAULT_REDIRECT = setting('SOCIAL_AUTH_LOGIN_REDIRECT_URL') or \
                    setting('LOGIN_REDIRECT_URL')
```

The 'or' clause forces reverse_lazy to evalute to check if the value it's True/False. As DEFAULT_REDIRECT is defined in import time the URLConf of the application is not ready yet.

To remove the use of 'or' I used the same approach as in the LOGIN_ERROR_URL variable.
