### PR TITLE
The BrowserID backend incorrectly uses the assertion expiration as the session expiration.

### DIFF
--- a/social_auth/backends/browserid.py
+++ b/social_auth/backends/browserid.py
@@ -41,14 +41,9 @@ class BrowserIDBackend(SocialAuthBackend):
 
     def extra_data(self, user, uid, response, details):
         """Return users extra data"""
-        # BrowserID sends timestamp for expiration date, here we
-        # comvert it to the remaining seconds
-        expires = (response['expires'] / 1000) - \
-                  time.mktime(datetime.now().timetuple())
         return {
             'audience': response['audience'],
-            'issuer': response['issuer'],
-            setting('SOCIAL_AUTH_EXPIRATION', 'expires'): expires
+            'issuer': response['issuer']
         }
 
 


### PR DESCRIPTION
From the the Persona (what BrowserID was renamed to) [Docs](https://developer.mozilla.org/en-US/docs/Persona/Protocol_Overview):

> In order to prove ownership of a private key, the user's browser creates and signs a new document called an "identity assertion." It contains:
> - The domain of the RP that the user wants to sign into.
> - **An expiration time for the assertion, _generally less than five minutes_ after it was created.**
> - The browser then presents both the user certificate and the identity assertion to the RP for verification.

(Emphasis mine).

From the code:

``` python
    def extra_data(self, user, uid, response, details):
        """Return users extra data"""
        # BrowserID sends timestamp for expiration date, here we
        # comvert it to the remaining seconds
        expires = (response['expires'] / 1000) - \
                  time.mktime(datetime.now().timetuple())
        return {
            'audience': response['audience'],
            'issuer': response['issuer'],
            setting('SOCIAL_AUTH_EXPIRATION', 'expires'): expires
        }
```

As you can see, django-social-auth is assuming that the expiration is when we should expire the session, and re-authenticate, but as you can see from the Persona docs, that leads to an issue where the user is being signed in for less than 5 minutes! (This took me forever to diagnose.)

Currently, the only way to use Persona and not constantly sign in is to turn off session expiration entirely. I'd rather not do that for all providers.

Persona doesn't seem to set any limitations on the actual session expiration; I've been unable to find any documentation on that. As such, I believe that we should simply remove the code that sets the expiration.
