### PR TITLE
Deal with IntegrityError when signing up a django 1.5 custom model user

### DIFF
--- a/social_auth/views.py
+++ b/social_auth/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth import login, REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.views.decorators.csrf import csrf_exempt
+from django.db import IntegrityError
 
 from social_auth.utils import sanitize_redirect, setting, \
                               backend_setting, clean_partial_pipeline
@@ -98,7 +99,13 @@ def complete_process(request, backend, *args, **kwargs):
     # pop redirect value before the session is trashed on login()
     redirect_value = request.session.get(REDIRECT_FIELD_NAME, '') or \
                      request.REQUEST.get(REDIRECT_FIELD_NAME, '')
-    user = auth_complete(request, backend, *args, **kwargs)
+    # Django 1.5 allow us to define custom User Model, so integrity errors
+    # can be raised.
+    try:
+        user = auth_complete(request, backend, *args, **kwargs)
+    except IntegrityError:
+        url = setting('SIGNUP_ERROR_URL', setting('LOGIN_ERROR_URL'))
+        return HttpResponseRedirect(url)
 
     if isinstance(user, HttpResponse):
         return user


### PR DESCRIPTION
Django 1.5 allow us to create custom user models. In my case, my user model specify the email field as unique. When I try to sign up with a social account (e.g. Google account) and the e-mail assigned to this account is already in use by another user of my site, an exception was raised (IntegrityError). With this patch, developers can define a URL to be redirected to when an IntegrityError is raised.
