### PR TITLE
Not implemented removeAssociation function in DjangoOpenIDStore raises an exception

### DIFF
--- a/social_auth/db/base.py
+++ b/social_auth/db/base.py
@@ -164,6 +164,16 @@ class UserSocialAuthMixin(object):
         assoc.save()
 
     @classmethod
+    def remove_association(cls, server_url, handle):
+        from social_auth.models import Association
+        assocs = list(Association.objects.filter(
+            server_url=server_url, handle=handle))
+        assocs_exist = len(assocs) > 0
+        for assoc in assocs:
+            assoc.delete()
+        return assocs_exist
+
+    @classmethod
     def get_oid_associations(cls, server_url, handle=None):
         from social_auth.models import Association
         args = {'server_url': server_url}

--- a/social_auth/store.py
+++ b/social_auth/store.py
@@ -18,6 +18,9 @@ class DjangoOpenIDStore(OpenIDStore):
         """Store new assocition if doesn't exist"""
         UserSocialAuth.store_association(server_url, association)
 
+    def removeAssociation(self, server_url, handle):
+        return UserSocialAuth.remove_association(server_url, handle)
+
     def getAssociation(self, server_url, handle=None):
         """Return stored assocition"""
         oid_associations = UserSocialAuth.get_oid_associations(server_url,


### PR DESCRIPTION
python openid tries to remove an association when the openid provider says the association is expired but the application thinks the association is valid. The removeAssociation method is not implemented in DjangoOpenIDStore and hence the following exception is raised. 
This rarely happens though as it can happen only in the last fraction of seconds  when the association is transitioning from valid to expired state.

Stacktrace (most recent call last):

  File "django/core/handlers/base.py", line 111, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)
  File "django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(_args, *_kwargs)
  File "social_auth/decorators.py", line 26, in wrapper
    return func(request, request.social_auth_backend, _args, *_kwargs)
  File "social_auth/views.py", line 39, in complete
    return complete_process(request, backend, _args, *_kwargs)
  File "social_auth/views.py", line 97, in complete_process
    user = auth_complete(request, backend, _args, *_kwargs)
  File "social_auth/views.py", line 172, in auth_complete
    return backend.auth_complete(user=user, request=request, _args, *_kwargs)
  File "social_auth/backends/**init**.py", line 470, in auth_complete
    self.build_absolute_uri())
  File "openid/consumer/consumer.py", line 414, in complete
    response = self.consumer.complete(message, endpoint, current_url)
  File "openid/consumer/consumer.py", line 619, in complete
    return modeMethod(message, endpoint, return_to)
  File "openid/consumer/consumer.py", line 646, in _complete_id_res
    return self._doIdRes(message, endpoint, return_to)
  File "openid/consumer/consumer.py", line 735, in _doIdRes
    self._idResCheckSignature(message, endpoint.server_url)
  File "openid/consumer/consumer.py", line 803, in _idResCheckSignature
    if not self._checkAuth(message, server_url):
  File "openid/consumer/consumer.py", line 1106, in _checkAuth
    return self._processCheckAuthResponse(response, server_url)
  File "openid/consumer/consumer.py", line 1141, in _processCheckAuthResponse
    self.store.removeAssociation(server_url, invalidate_handle)
  File "openid/store/interface.py", line 125, in removeAssociation
    raise NotImplementedError
