### PR TITLE
Fix for missing full name when retrieving Instagram user details

### DIFF
--- a/social_auth/backends/contrib/instagram.py
+++ b/social_auth/backends/contrib/instagram.py
@@ -21,7 +21,7 @@ class InstagramBackend(OAuthBackend):
     def get_user_details(self, response):
         """Return user details from Instagram account"""
         username = response['user']['username']
-        fullname = response['user'].get('fullname', '')
+        fullname = response['user'].get('full_name', '')
         email = response['user'].get('email', '')
         return {
             USERNAME: username,


### PR DESCRIPTION
The key for the user's full name is `full_name`

See: http://instagram.com/developer/authentication/
