### PR TITLE
Added GITHUB_ORGANIZATION setting which will allow users to constrain to a given GitHub organization if set. 

### DIFF
--- a/doc/backends/github.rst
+++ b/doc/backends/github.rst
@@ -12,6 +12,11 @@ Github works similar to Facebook (OAuth).
 
 - Also it's possible to define extra permissions with::
 
-     GITHUB_EXTENDED_PERMISSIONS = [...]
+      GITHUB_EXTENDED_PERMISSIONS = [...]
+
+- Optional ``GitHub Organization``, which if set will allow you to constrain
+  authentication to a given GitHub organization::
+
+      GITHUB_ORGANIZATION = ''
 
 .. _GitHub Developers: https://github.com/settings/applications/new

--- a/social_auth/backends/contrib/github.py
+++ b/social_auth/backends/contrib/github.py
@@ -5,6 +5,9 @@ This contribution adds support for GitHub OAuth service. The settings
 GITHUB_APP_ID and GITHUB_API_SECRET must be defined with the values
 given by GitHub application registration process.
 
+GITHUB_ORGANIZATION is an optional setting that will allow you to constrain
+authentication to a given GitHub organization.
+
 Extended permissions are supported by defining GITHUB_EXTENDED_PERMISSIONS
 setting, it must be a list of values to request.
 
@@ -12,8 +15,10 @@ By default account id and token expiration time are stored in extra_data
 field, check OAuthBackend class for details on how to extend it.
 """
 from urllib import urlencode
+from urllib2 import HTTPError
 
 from django.utils import simplejson
+from django.conf import settings
 
 from social_auth.utils import setting, dsa_urlopen
 from social_auth.backends import BaseOAuth2, OAuthBackend, USERNAME
@@ -23,6 +28,10 @@ from social_auth.backends import BaseOAuth2, OAuthBackend, USERNAME
 GITHUB_AUTHORIZATION_URL = 'https://github.com/login/oauth/authorize'
 GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
 GITHUB_USER_DATA_URL = 'https://api.github.com/user'
+
+# GitHub organization configuration
+GITHUB_ORGANIZATION_MEMBER_OF_URL = 'https://api.github.com/orgs/{org}/members/{username}'
+
 GITHUB_SERVER = 'github.com'
 
 
@@ -53,16 +62,36 @@ class GithubAuth(BaseOAuth2):
     # Look at http://developer.github.com/v3/oauth/
     SCOPE_VAR_NAME = 'GITHUB_EXTENDED_PERMISSIONS'
 
+    GITHUB_ORGANIZATION = getattr(settings, 'GITHUB_ORGANIZATION', None)
+
     def user_data(self, access_token, *args, **kwargs):
         """Loads user data from service"""
-        url = GITHUB_USER_DATA_URL + '?' + urlencode({
-            'access_token': access_token
-        })
-        try:
-            return simplejson.load(dsa_urlopen(url))
-        except ValueError:
-            return None
+        url = GITHUB_USER_DATA_URL + '?' + urlencode({'access_token': access_token})
 
+        try:
+            data = simplejson.load(dsa_urlopen(url))
+        except ValueError:
+            data = None
+
+        # if we have a github organization defined, test that the current users is
+        # a member of that organization.
+        if data and self.GITHUB_ORGANIZATION:
+            member_url = GITHUB_ORGANIZATION_MEMBER_OF_URL.format(
+                org=self.GITHUB_ORGANIZATION,
+                username=data.get('login')
+            )
+
+            try:
+                response = dsa_urlopen(member_url)
+            except HTTPError:
+                data = None
+            else:
+                # if the user is a member of the organization, response code will be 204
+                # see: http://developer.github.com/v3/orgs/members/#response-if-requester-is-an-organization-member-and-user-is-a-member
+                if not response.code == 204:
+                    data = None
+
+        return data
 
 # Backend definition
 BACKENDS = {


### PR DESCRIPTION
This patch will allow users to add an optional GITHUB_ORGANIZATION
setting to their settings.py file which will constrain authentication
to the defined GitHub organization.

If no GitHub organization is defined, authentication will not be
constrained and the backend will work as before.

Also updated the documentation to explain option usage of the
GITHUB_ORGANIZATION setting.
