### PR TITLE
For people with Cyrillic characters

### DIFF
--- a/social_auth/backends/pipeline/user.py
+++ b/social_auth/backends/pipeline/user.py
@@ -1,4 +1,5 @@
 from uuid import uuid4
+from django.template.defaultfilters import slugify
 
 from social_auth.utils import setting
 from social_auth.models import UserSocialAuth
@@ -31,7 +32,7 @@ def get_username(details, user=None,
     # username is cut to avoid any field max_length.
     while user_exists(username=final_username):
         username = short_username + uuid4().get_hex()[:uuid_length]
-        final_username = UserSocialAuth.clean_username(username[:max_length])
+        final_username = UserSocialAuth.clean_username(slugify(username[:max_length]))
 
     return {'username': final_username}
 


### PR DESCRIPTION
Added slugify to the final username that gets created.
Many times it has happened that when users comes from Facebook or Linkedin and don't have a username set on the social service their username is compiled from First name + Last name (AndersAnderssön) with slugify you now simply get andersandersson, when trying to make clean URL's like /profiles/<username> you end up getting a 500 error request.
