### PR TITLE
Update social_auth/urls.py

### DIFF
--- a/social_auth/urls.py
+++ b/social_auth/urls.py
@@ -3,7 +3,7 @@ try:
     from django.conf.urls import patterns, url 
 except ImportError: 
     # for Django version less then 1.4
-    from django.conf.urls.default import patterns, url
+    from django.conf.urls.defaults import patterns, url
     
 from social_auth.views import auth, complete, disconnect
 


### PR DESCRIPTION
fix deprecated for Django 1.5
