### PR TITLE
remove unnecessary South documentation, fix typos

### DIFF
--- a/doc/miscellaneous.rst
+++ b/doc/miscellaneous.rst
@@ -8,19 +8,6 @@ Join to `django-social-auth discussion list`_ and bring any questions or suggest
 that would improve this application.
 
 
-South users
------------
-
-South_ users should add this rule to enable migrations::
-
-    try:
-        import south
-        from south.modelsinspector import add_introspection_rules
-        add_introspection_rules([], ["^social_auth\.fields\.JSONField"])
-    except:
-        pass
-
-
 Custom User model
 -----------------
 
@@ -34,7 +21,7 @@ Third party backends
 --------------------
 
 There's an ongoing movement to create a list of third party backends on
-djangopackages.com_, so, if somebody doesn't want it's backend in the
+djangopackages.com_, so, if somebody doesn't want its backend in the
 ``contrib`` directory but still wants to share, just split it in a separated
 package and link it there.
 
@@ -42,10 +29,10 @@ package and link it there.
 Python 2.7.2rev4, 2.7.3 and Facebook backend
 -------------------------------------------
 
-Seems that this bug described in StackOverflow_ hits users using
+It seems that this bug described in StackOverflow_ hits users using
 django-social-auth_ with Python versions 2.7.2rev4 and 2.7.3 (so far) and
 Facebook backend. The bug report `#315`_ explains it a bit more and shows
-a workaround fit avoid it.
+a workaround fit to avoid it.
 
 
 Server date time


### PR DESCRIPTION
The proposed South snippet is already in social_auth/fields.py and a "manage.py syncdb --migrate" shows social_auth as being migrated as opposed to being synced by default, so I /believe/ this is no longer necessary, but if I'm wrong, please reject and I'll just send a typo pull request. Thanks!
