### PR TITLE
Keep the full email address as username

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -421,6 +421,13 @@ uppercase and replace ``-`` with ``_``), here's the supported settings so far::
   The feature is disabled by default to keep backward compatibility and to not
   force this option on projects where Unicode usernames are a valid choice.
 
+- If you want to use the full email address as the username, define this setting::
+
+    SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL = True
+
+  Make sure you don't use the "slugify" option described above, as the "@" sign
+  would be removed.
+
 
 Notes
 -----

--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -291,10 +291,16 @@ class OpenIDBackend(SocialAuthBackend):
             except ValueError:
                 last_name = fullname
 
+        if setting('SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL', False) \
+                and values.get("email"):
+            username = values.get("email")
+        elif values.get(USERNAME):
+            username = values.get(USERNAME)
+        else:
+            username = first_name.title() + last_name.title()
         values.update({'fullname': fullname, 'first_name': first_name,
                        'last_name': last_name,
-                       USERNAME: values.get(USERNAME) or
-                                   (first_name.title() + last_name.title())})
+                       USERNAME: username})
         return values
 
     def extra_data(self, user, uid, response, details):

--- a/social_auth/backends/browserid.py
+++ b/social_auth/backends/browserid.py
@@ -32,12 +32,15 @@ class BrowserIDBackend(SocialAuthBackend):
         #  'expires': 1328983575529,
         #  'email': 'name@server.com',
         #  'issuer': 'login.persona.org'}
-        email = response['email']
-        return {USERNAME: email.split('@', 1)[0],
-                'email': email,
-                'fullname': '',
-                'first_name': '',
-                'last_name': ''}
+        details = {'email': response['email'],
+                   'fullname': '',
+                   'first_name': '',
+                   'last_name': ''}
+        if setting('SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL', False):
+            details[USERNAME] = details["email"]
+        else:
+            details[USERNAME] = details["email"].split('@', 1)[0]
+        return details
 
     def extra_data(self, user, uid, response, details):
         """Return users extra data"""

--- a/social_auth/backends/facebook.py
+++ b/social_auth/backends/facebook.py
@@ -60,11 +60,15 @@ class FacebookBackend(OAuthBackend):
 
     def get_user_details(self, response):
         """Return user details from Facebook account"""
-        return {USERNAME: response.get('username', response.get('name')),
-                'email': response.get('email', ''),
-                'fullname': response.get('name', ''),
-                'first_name': response.get('first_name', ''),
-                'last_name': response.get('last_name', '')}
+        details = {USERNAME: response.get('username', response.get('name')),
+                   'email': response.get('email', ''),
+                   'fullname': response.get('name', ''),
+                   'first_name': response.get('first_name', ''),
+                   'last_name': response.get('last_name', '')}
+        if setting('SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL', False) \
+                and detais["email"]:
+            details[USERNAME] = details["email"]
+        return details
 
 
 class FacebookAuth(BaseOAuth2):

--- a/social_auth/backends/google.py
+++ b/social_auth/backends/google.py
@@ -58,12 +58,15 @@ class GoogleOAuthBackend(OAuthBackend):
 
     def get_user_details(self, response):
         """Return user details from Orkut account"""
-        email = response.get('email', '')
-        return {USERNAME: email.split('@', 1)[0],
-                'email': email,
-                'fullname': '',
-                'first_name': '',
-                'last_name': ''}
+        details = {'email': response.get('email', ''),
+                   'fullname': '',
+                   'first_name': '',
+                   'last_name': ''}
+        if setting('SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL', False):
+            details[USERNAME] = details["email"]
+        else:
+            details[USERNAME] = details["email"].split('@', 1)[0]
+        return details
 
 
 class GoogleOAuth2Backend(GoogleOAuthBackend):
@@ -84,12 +87,15 @@ class GoogleOAuth2Backend(GoogleOAuthBackend):
         return user_id
 
     def get_user_details(self, response):
-        email = response.get('email', '')
-        return {USERNAME: email.split('@', 1)[0],
-                'email': email,
-                'fullname': response.get('name', ''),
-                'first_name': response.get('given_name', ''),
-                'last_name': response.get('family_name', '')}
+        details = {'email': response.get('email', ''),
+                   'fullname': response.get('name', ''),
+                   'first_name': response.get('given_name', ''),
+                   'last_name': response.get('family_name', '')}
+        if setting('SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL', False):
+            details[USERNAME] = details["email"]
+        else:
+            details[USERNAME] = details["email"].split('@', 1)[0]
+        return details
 
 
 class GoogleBackend(OpenIDBackend):


### PR DESCRIPTION
The point of this commit is to keep the full email adress as the username for the backends that are email-based (and were deducing the username by splitting the address).

There's an associated configuration switch.
