### PR TITLE
One line fix to update Google App Engine backend to work with latest version of django-social-auth

### DIFF
--- a/social_auth/backends/contrib/gae.py
+++ b/social_auth/backends/contrib/gae.py
@@ -1,5 +1,11 @@
 """
 Google App Engine support using User API
+
+This backend is for use of django-social-auth on top
+of Google's App Engine PaaS.
+
+This backend directly uses Google's User API that
+is available on the App Engine platform.
 """
 from __future__ import absolute_import
 
@@ -57,5 +63,5 @@ class GAEAuth(BaseAuth):
 
 # Backend definition
 BACKENDS = {
-    'gae': GAEAuth,
+    'google-appengine': GAEAuth,
 }


### PR DESCRIPTION
Initially GAEBackend.name did not match the name in BACKENDS, it worked fine.
In newer versions the names need to match in order to get loaded.

Note that this change in the name will affect the login url, since it's matched against the value in BACKENDS.
