### PR TITLE
make user detection by email address case-insensitive

### DIFF
--- a/social_auth/backends/pipeline/associate.py
+++ b/social_auth/backends/pipeline/associate.py
@@ -15,8 +15,9 @@ def associate_by_email(details, user=None, *args, **kwargs):
         # try to associate accounts registered with the same email address,
         # only if it's a single object. AuthException is raised if multiple
         # objects are returned
+        # Allow case-insensitive match, since real-world email address is case-insensitive
         try:
-            return {'user': UserSocialAuth.get_user_by_email(email=email)}
+            return {'user': UserSocialAuth.get_user_by_email(email__iexact=email)}
         except MultipleObjectsReturned:
             raise AuthException(kwargs['backend'], 'Not unique email address.')
         except ObjectDoesNotExist:

--- a/social_auth/db/base.py
+++ b/social_auth/db/base.py
@@ -109,6 +109,7 @@ class UserSocialAuthMixin(object):
         """
         Return True/False if a User instance exists with the given arguments.
         Arguments are directly passed to filter() manager method.
+        TODO: consider how to ensure case-insensitive email matching
         """
         return cls.user_model().objects.filter(*args, **kwargs).count() > 0
 
@@ -127,7 +128,8 @@ class UserSocialAuthMixin(object):
 
     @classmethod
     def get_user_by_email(cls, email):
-        return cls.user_model().objects.get(email=email)
+        "Case insensitive search"
+        return cls.user_model().objects.get(email__iexact=email)
 
     @classmethod
     def resolve_user_or_id(cls, user_or_id):


### PR DESCRIPTION
Problem:: email address with different case causing a duplicate auth_users entry, which led to the following error on /login/

"MultipleObjectsReturned: get() returned more than one User -- it returned 2! Lookup parameters were {'email': u'auser@msn.com'}"

Of the two entries, one from fb, the other an email/password login, one was auser@msn, the other was Auser@msn.

Solution:: make the matching in association and base be  case-insensitive.

Due-Diligence:: Google "django email__iexact=email" to see that several others have already crossed this bridge before.  

Note:: I add a TODO in simple_user_exists, since I believe the same problem might occur there, depending how it's used. 
