### PR TITLE
Return value fix for pipeline social associate user function

### DIFF
--- a/social_auth/backends/pipeline/social.py
+++ b/social_auth/backends/pipeline/social.py
@@ -28,7 +28,7 @@ def social_auth_user(backend, uid, user=None, *args, **kwargs):
 def associate_user(backend, user, uid, social_user=None, *args, **kwargs):
     """Associate user social account with user instance."""
     if social_user or not user:
-        return {}
+        return None
 
     try:
         social = UserSocialAuth.create_social_auth(user, uid, backend.name)


### PR DESCRIPTION
Hi! 

Is there a special reason for returning None and {} in these if statements? What's the difference or returning None or empty dict?

```
if social_user:
    return None

if not user:
     return {}
```

when a pipeline is returned, it goes into that line of pipeline function of backend.SocialAuthBackend class. 

```
result = func(*args, **out) or {}
...
if isinstance(result, dict):
    out.update(result)
```

So, with {}, out.update doesn't change anything. If we return None, this out.update will not be called.

And here is the patch for doing this. Please correct me if I'm missing smt.

Thanks.
