### PR TITLE
Update to Angel List documentation

### DIFF
--- a/doc/backends/angel.rst
+++ b/doc/backends/angel.rst
@@ -11,7 +11,7 @@ Angel uses OAuth v2 for Authentication
 
 - extra scopes can be defined by using::
 
-    ANGEL_AUTH_EXTRA_ARGUMENTS = {'scope': 'email messages'}
+    ANGEL_AUTH_EXTRA_ARGUMENTS = {'scope': 'email message'}
 
 *Note:*
 Angel List does not currently support returning 'state' variable.


### PR DESCRIPTION
In the Angel List documentation it should read
ANGEL_AUTH_EXTRA_ARGUMENTS = {'scope': 'email message'}
not
ANGEL_AUTH_EXTRA_ARGUMENTS = {'scope': 'email messages'}
otherwise it doesn't let you read and send messages on the users behalf
