### PR TITLE
Truncate values that are too big to fit in the DB

### DIFF
--- a/social_auth/backends/pipeline/user.py
+++ b/social_auth/backends/pipeline/user.py
@@ -81,6 +81,10 @@ def update_user_details(backend, details, response, user=None, is_new=False,
         if name in ('username', 'id', 'pk') or (not is_new and
            name in setting('SOCIAL_AUTH_PROTECTED_USER_FIELDS', [])):
             continue
+        field = user._meta.get_field(name)
+        if field and len(value) > field.max_length:
+            # The whole field can't fit in the DB. Truncate it instead of failing on user.save()
+            value = value[:field.max_length]
         if value and value != getattr(user, name, None):
             setattr(user, name, value)
             changed = True


### PR DESCRIPTION
I ran into an issue when a GitHub user with a name longer than 30 characters tried to sign in to my site (@Nerian in case he's paying attention). Instead of signing him in, django-social-auth raised a DatabaseError:

```
*snip*

File "/usr/local/lib/python2.7/dist-packages/social_auth/backends/pipeline/user.py", line 105, in update_user_details
   user.save()

*snip*

DatabaseError: value too long for type character varying(30)
```

This patch fixes the error for any field. It should also work with custom User models, since it inspects the max_length of each field. There are some cases where a truncated value isn't useful (email addresses, for example), but I still think truncating is better than showing the user an internal server error.

I'll be honest: I didn't run tests before submitting this, so I don't know if the truncation breaks any of them. I'm sort of paranoid about giving my Twitter, Google, Facebook, and Linkedin credentials to code I haven't read.
