### PR TITLE
Fixed restricting guthub authorization to a single organiszation.

### DIFF
--- a/social_auth/backends/contrib/github.py
+++ b/social_auth/backends/contrib/github.py
@@ -82,7 +82,9 @@ class GithubAuth(BaseOAuth2):
             member_url = GITHUB_ORGANIZATION_MEMBER_OF_URL.format(
                 org=self.GITHUB_ORGANIZATION,
                 username=data.get('login')
-            )
+            ) + '?' + urlencode({
+                'access_token': access_token
+            })
 
             try:
                 response = dsa_urlopen(member_url)


### PR DESCRIPTION
This takes care of the below exception when a user in an organization attempts to log in with the GitHub backend.

I expect there may still be a case where a user **not** in the organization logs in.

``` python
Internal Server Error: /github-jenkins/complete/github/
Traceback (most recent call last):
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/django/core/handlers/base.py", line 115, in get_response
    response = callback(request, *callback_args, **callback_kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(*args, **kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/decorators.py", line 29, in wrapper
    return func(request, request.social_auth_backend, *args, **kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/views.py", line 42, in complete
    return complete_process(request, backend, *args, **kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/views.py", line 111, in complete_process
    user = auth_complete(request, backend, *args, **kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/views.py", line 197, in auth_complete
    return backend.auth_complete(user=user, request=request, *args, **kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/backends/__init__.py", line 836, in auth_complete
    *args, **kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/backends/__init__.py", line 873, in do_auth
    return authenticate(*args, **kwargs)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/django/contrib/auth/__init__.py", line 59, in authenticate
    user = backend.authenticate(**credentials)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/backends/__init__.py", line 104, in authenticate
    kwargs['uid'] = self.get_user_id(kwargs['details'], response)
  File "/home/sjagoe/ve-github-jenkins/lib/python2.6/site-packages/social_auth/backends/__init__.py", line 209, in get_user_id
    return response[self.ID_KEY]
KeyError: 'id'
```
