### PR TITLE
Removed deprecated simplejson for json

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -34,6 +34,10 @@ from social_auth.exceptions import StopPipeline, AuthException, AuthFailed, \
                                    NotAllowedToDisconnect
 from social_auth.backends.utils import build_consumer_oauth_request
 
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
 
 # OpenID configuration
 OLD_AX_ATTRS = [

--- a/social_auth/backends/browserid.py
+++ b/social_auth/backends/browserid.py
@@ -2,13 +2,16 @@
 BrowserID support
 """
 from urllib import urlencode
-import json
 from django.contrib.auth import authenticate
 
 from social_auth.backends import SocialAuthBackend, BaseAuth
 from social_auth.utils import log, dsa_urlopen
 from social_auth.exceptions import AuthFailed, AuthMissingParameter
 
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
 
 # BrowserID verification server
 BROWSER_ID_SERVER = 'https://verifier.login.persona.org/verify'

--- a/social_auth/backends/facebook.py
+++ b/social_auth/backends/facebook.py
@@ -18,7 +18,12 @@ import hashlib
 import time
 from urllib import urlencode
 from urllib2 import HTTPError
-import json
+
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
+    
 from django.contrib.auth import authenticate
 from django.http import HttpResponse
 from django.template import TemplateDoesNotExist, RequestContext, loader

--- a/social_auth/backends/google.py
+++ b/social_auth/backends/google.py
@@ -15,7 +15,12 @@ OpenID also works straightforward, it doesn't need further configurations.
 """
 from urllib import urlencode
 from urllib2 import Request
-import json
+
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
+
 from oauth2 import Request as OAuthRequest
 
 from social_auth.utils import setting, dsa_urlopen

--- a/social_auth/backends/reddit.py
+++ b/social_auth/backends/reddit.py
@@ -5,7 +5,10 @@ from urllib import urlencode
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen
 from social_auth.exceptions import AuthTokenError
-import json
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
 
 class RedditBackend(OAuthBackend):
     """Reddit OAuth2 authentication backend"""

--- a/social_auth/backends/steam.py
+++ b/social_auth/backends/steam.py
@@ -6,7 +6,10 @@ import urllib2
 from social_auth.backends import OpenIdAuth, OpenIDBackend
 from social_auth.exceptions import AuthFailed
 from social_auth.utils import setting
-import json
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
 
 STEAM_ID = re.compile('steamcommunity.com/openid/id/(.*?)$')
 USER_INFO = 'http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?'

--- a/social_auth/backends/twitter.py
+++ b/social_auth/backends/twitter.py
@@ -13,7 +13,10 @@ class for details on how to extend it.
 """
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 from social_auth.exceptions import AuthCanceled
-import json
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
 
 # Twitter configuration
 TWITTER_SERVER = 'api.twitter.com'

--- a/social_auth/backends/utils.py
+++ b/social_auth/backends/utils.py
@@ -3,7 +3,10 @@ from oauth2 import Consumer as OAuthConsumer, Token, Request as OAuthRequest, \
 
 from social_auth.models import UserSocialAuth
 from social_auth.utils import dsa_urlopen
-
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
 
 def consumer_oauth_url_request(backend, url, user_or_id, redirect_uri='/',
                                json=True):

--- a/social_auth/fields.py
+++ b/social_auth/fields.py
@@ -1,7 +1,10 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import smart_unicode
-import json
+try:
+    import json
+except ImportError: # python < 2.6
+    from django.utils import simplejson as json
 
 class JSONField(models.TextField):
     """Simple JSON field that stores python structures as JSON strings


### PR DESCRIPTION
Replaced simplejson calls with json calls across the backend.  simplejson is now deprecated and these fixes correct all of the deprecation errors.
