### PR TITLE
fixed facebook backend with new-style response returned from parse_qs

### DIFF
--- a/social_auth/backends/facebook.py
+++ b/social_auth/backends/facebook.py
@@ -119,9 +119,9 @@ class FacebookAuth(BaseOAuth2):
                 raise AuthFailed(self, 'There was an error authenticating '
                                        'the app')
 
-            access_token = response['access_token'][0]
+            access_token = response['access_token']
             if 'expires' in response:
-                expires = response['expires'][0]
+                expires = response['expires']
 
         if 'signed_request' in self.data:
             response = load_signed_request(


### PR DESCRIPTION
I was having trouble logging in with facebook on the requests branch in django 1.5.1 (see screenshot below) and realized that the problem was related to a change in how the `request` object in the facebook backend were handled now that `parse_qs` gets rid of lists with  `drop_lists`.

Its unclear to me whether other backends might be affected, but it looks like xing, stackoverflow, and yammer might have similar problems but I'm less confident in that:

```
[term]$ cd social_auth/backends
[term]$ grep "\[0\]" `find . -name "*.py" | xargs grep parse_qs | sed 's/:/ /' | awk '{print $1}' | uniq`
./contrib/xing.py:        profile = simplejson.loads(content)['users'][0]
./contrib/stackoverflow.py:            return data.get('items')[0]
./contrib/yammer.py:        email = response['user']['contact']['email_addresses'][0]['address']
./contrib/yammer.py:                data['code'] = extra['code'][0]
```

![Screen shot 2013-04-15 at 17 09 13](https://f.cloud.github.com/assets/255672/385674/197f3b38-a68c-11e2-809f-cf3fcda2be84.png)
