### PR TITLE
Add Fedora OpenID support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,7 @@ credentials. Some features are:
     * `Shopify OAuth2`_
     * `StockTwits OAuth2`_
     * `Stackoverflow OAuth2`_
+    * `Fedora OpenID`_
 
 - Basic user data population and signaling to allows custom fields values
   from providers' responses
@@ -192,3 +193,4 @@ Some bits were derived from others' work and copyrighted by:
 .. _github: https://github.com/omab/django-social-auth
 .. _django-social-auth discussion list: https://groups.google.com/forum/?fromgroups#!forum/django-social-auth
 .. _Stackoverflow OAuth2: http://api.stackexchange.com/
+.. _Fedora OpenID: https://fedoraproject.org/wiki/OpenID

--- a/django-social-auth.spec
+++ b/django-social-auth.spec
@@ -37,7 +37,7 @@ mechanism for Django projects.
 
 This application provides user registration and login using social sites
 supporting OpenID, OAuth and OAuth2 such as Google, Yahoo, Twitter, Facebook,
-LiveJournal, Orkut, LinkedIn, Foursquare, GitHub, DropBox, Flickr.
+LiveJournal, Orkut, LinkedIn, Foursquare, GitHub, DropBox, Flickr, Fedora.
 
 %package docs
 Summary:        Documentation for %{name}

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -36,6 +36,7 @@ Application Setup
         'social_auth.backends.contrib.skyrock.SkyrockBackend',
         'social_auth.backends.contrib.yahoo.YahooOAuthBackend',
         'social_auth.backends.contrib.readability.ReadabilityBackend',
+        'social_auth.backends.contrib.fedora.FedoraBackend',
         'social_auth.backends.OpenIDBackend',
         'django.contrib.auth.backends.ModelBackend',
     )

--- a/doc/contributions.rst
+++ b/doc/contributions.rst
@@ -80,6 +80,9 @@ uruz_ (Alexey Boriskin)
   * Odnoklassniki.ru iframe applications support
   * VK.com backend improvements
 
+abompard_ (Aurélien Bompard)
+  * Fedora OpenID support
+
 .. _caioariede: https://github.com/caioariede
 .. _krvss: https://github.com/krvss
 .. _jezdez: https://github.com/jezdez
@@ -104,3 +107,4 @@ uruz_ (Alexey Boriskin)
 .. _northisup: https://github.com/northisup
 .. _kjoconnor: https://github.com/kjoconnor
 .. _uruz: https://github.com/uruz
+.. _abompard: https://github.com/abompard

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -53,6 +53,7 @@ credentials. Some features are:
     * `Yandex OpenId`_
     * `Readability OAuth`_
     * `Stackoverflow OAuth2`_
+    * `Fedora OpenID`_
 
 - Basic user data population and signaling, to allows custom fields values
   from providers response
@@ -101,3 +102,4 @@ credentials. Some features are:
 .. _Yandex OpenId: http://openid.yandex.ru/
 .. _Readability OAuth: http://www.readability.com/developers/api
 .. _Stackoverflow OAuth2: http://api.stackexchange.com/
+.. _Fedora OpenID: https://fedoraproject.org/wiki/OpenID

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -144,6 +144,7 @@ AUTHENTICATION_BACKENDS = (
     'social_auth.backends.contrib.stocktwits.StocktwitsBackend',
     'social_auth.backends.contrib.behance.BehanceBackend',
     'social_auth.backends.contrib.readability.ReadabilityBackend',
+    'social_auth.backends.contrib.fedora.FedoraBackend',
     'social_auth.backends.steam.SteamBackend',
     'social_auth.backends.reddit.RedditBackend',
     'django.contrib.auth.backends.ModelBackend',

--- a/social_auth/backends/contrib/fedora.py
+++ b/social_auth/backends/contrib/fedora.py
@@ -1,0 +1,29 @@
+"""
+Fedora OpenID support
+
+No extra configurations are needed to make this work.
+"""
+from social_auth.backends import OpenIDBackend, OpenIdAuth
+
+
+FEDORA_OPENID_URL = 'https://id.fedoraproject.org'
+
+
+class FedoraBackend(OpenIDBackend):
+    """Fedora OpenID authentication backend"""
+    name = 'fedora'
+
+
+class FedoraAuth(OpenIdAuth):
+    """Fedora OpenID authentication"""
+    AUTH_BACKEND = FedoraBackend
+
+    def openid_url(self):
+        """Return Fedora OpenID service url"""
+        return FEDORA_OPENID_URL
+
+
+# Backend definition
+BACKENDS = {
+    'fedora': FedoraAuth,
+}


### PR DESCRIPTION
Hey!

The Fedora project provides an OpenID server to its contributors, here's a very simple backend for django-social-auth.
Are you OK with including it ?

Cheers,
Aurélien
