### PR TITLE
Squelch exceptions caused if len() can't be called on a value in pipeline.user.django_orm_maxlength_truncate

### DIFF
--- a/social_auth/backends/pipeline/user.py
+++ b/social_auth/backends/pipeline/user.py
@@ -85,8 +85,11 @@ def mongoengine_orm_maxlength_truncate(backend, details, user=None,
     for name, value in details.iteritems():
         if name in names and not _ignore_field(name, is_new):
             max_length = user._fields[name].max_length
-            if max_length and len(value) > max_length:
-                value = value[:max_length]
+            try:
+                if max_length and len(value) > max_length:
+                    value = value[:max_length]
+            except TypeError:
+                pass
         out[name] = value
     return {'details': out}
 
@@ -102,8 +105,11 @@ def django_orm_maxlength_truncate(backend, details, user=None, is_new=False,
     for name, value in details.iteritems():
         if name in names and not _ignore_field(name, is_new):
             max_length = user._meta.get_field(name).max_length
-            if max_length and len(value) > max_length:
-                value = value[:max_length]
+            try:
+                if max_length and len(value) > max_length:
+                    value = value[:max_length]
+            except TypeError:
+                pass
         out[name] = value
     return {'details': out}
 


### PR DESCRIPTION
If you add django_orm_maxlength_truncate or mongoengine_orm_maxlength_truncate to your pipeline and any non-ignored field in a user object is None or a number, the user can't be created. GitHub allows empty names, so this caused some problems for me.
