### PR TITLE
Default to empty string if GitHub user has no name.

### DIFF
--- a/social_auth/backends/contrib/github.py
+++ b/social_auth/backends/contrib/github.py
@@ -49,7 +49,7 @@ class GithubBackend(OAuthBackend):
         """Return user details from Github account"""
         return {'username': response.get('login'),
                 'email': response.get('email') or '',
-                'first_name': response.get('name')}
+                'first_name': response.get('name') or ''}
 
 
 class GithubAuth(BaseOAuth2):


### PR DESCRIPTION
This fixes a bug where GitHub users who haven't set a name in their profile are unable to log in.
