### PR TITLE
Appsfuel OAuth2 Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ credentials. Some features are:
     * `Stackoverflow OAuth2`_
     * `Fedora OpenID`_
     * `Exacttarget HubExchange`_
+    * `Appsfuel OAuth2`_
 
 - Basic user data population and signaling to allows custom fields values
   from providers' responses
@@ -212,3 +213,4 @@ Some bits were derived from others' work and copyrighted by:
 .. _Stackoverflow OAuth2: http://api.stackexchange.com/
 .. _Fedora OpenID: https://fedoraproject.org/wiki/OpenID
 .. _Exacttarget HubExchange: http://code.exacttarget.com/
+.. _Appsfuel OAuth2: http://docs.appsfuel.com/api_reference#api_reference

--- a/doc/backends/appsfuel.rst
+++ b/doc/backends/appsfuel.rst
@@ -1,0 +1,34 @@
+Appsfuel
+========
+Appsfuel uses OAuth v2 for Authentication (`Official Docs`_)
+
+- Sign up at the `Appsfuel Developer Program`_
+
+- Create and verify a new app
+
+- On the dashboard click on **Show API keys**
+
+- Fill ``Client Id`` and ``Client Secret`` values in the settings::
+
+      APPSFUEL_CLIENT_ID = '<App UID>'
+      APPSFUEL_CLIENT_SECRET = '<App secret>'
+
+Appsfuel gives you the chance to integrate with **Live** or **Sandbox** env.
+
+Appsfuel Live
+-------------
+
+- Add 'social_auth.backends.contrib.appsfuel.AppsfuelBackend' into your AUTHENTICATION_BACKENDS.
+
+- Then you can start using {% url 'socialauth_begin' 'appsfuel' %} in your templates
+
+Appsfuel Sandbox
+----------------
+
+- Add 'social_auth.backends.contrib.appsfuel.AppsfuelSandboxBackend' into your AUTHENTICATION_BACKENDS.
+
+- Then you can start using {% url 'socialauth_begin' 'appsfuel-sandbox' %} in your templates
+
+
+.. _Official Docs: http://docs.appsfuel.com/api_reference#api_integration
+.. _Appsfuel Developer Program: https://developer.appsfuel.com

--- a/doc/backends/index.rst
+++ b/doc/backends/index.rst
@@ -11,6 +11,7 @@ Contents:
 
    amazon
    angel
+   appsfuel
    behance
    bitbucket
    browserid

--- a/social_auth/backends/contrib/appsfuel.py
+++ b/social_auth/backends/contrib/appsfuel.py
@@ -1,0 +1,66 @@
+"""
+This module is originally written: django-social-auth-appsfuel==1.0.0
+You could refer to https://github.com/AppsFuel/django-social-auth-appsfuel for issues
+
+settings.py should include the following:
+
+    APPSFUEL_CLIENT_ID = '...'
+    APPSFUEL_CLIENT_SECRET = '...'
+
+"""
+import json
+from urllib import urlencode
+from social_auth.backends import BaseOAuth2, OAuthBackend
+from social_auth.utils import dsa_urlopen
+
+
+class AppsfuelBackend(OAuthBackend):
+    name = 'appsfuel'
+
+    def get_user_id(self, details, response):
+        return response['user_id']
+
+    def get_user_details(self, response):
+        """Return user details from Appsfuel account"""
+        fullname = response.get('display_name', '')
+        email = response.get('email', '')
+        username = email.split('@')[0] if email else ''
+        return {
+            'username': username,
+            'first_name': fullname,
+            'email': email
+        }
+
+
+class AppsfuelAuth(BaseOAuth2):
+    """Appsfuel OAuth mechanism"""
+    AUTH_BACKEND = AppsfuelBackend
+    AUTHORIZATION_URL = 'http://app.appsfuel.com/content/permission'
+    ACCESS_TOKEN_URL = 'https://api.appsfuel.com/v1/live/oauth/token'
+    USER_URL = 'https://api.appsfuel.com/v1/live/user'
+    SETTINGS_KEY_NAME = 'APPSFUEL_CLIENT_ID'
+    SETTINGS_SECRET_NAME = 'APPSFUEL_CLIENT_SECRET'
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Loads user data from service"""
+        params = {'access_token': access_token}
+        url = self.USER_URL + '?' + urlencode(params)
+        return json.load(dsa_urlopen(url))
+
+
+class AppsfuelSandboxBackend(AppsfuelBackend):
+    name = 'appsfuel-sandbox'
+
+
+class AppsfuelSandboxAuth(AppsfuelAuth):
+    AUTH_BACKEND = AppsfuelSandboxBackend
+    AUTHORIZATION_URL = 'https://api.appsfuel.com/v1/sandbox/choose'
+    ACCESS_TOKEN_URL = 'https://api.appsfuel.com/v1/sandbox/oauth/token'
+    USER_URL = 'https://api.appsfuel.com/v1/sandbox/user'
+
+
+# Backend definitions
+BACKENDS = {
+    'appsfuel': AppsfuelAuth,
+    'appsfuel-sandbox': AppsfuelSandboxAuth,
+}


### PR DESCRIPTION
Appsfuel uses OAuth v2 for Authentication.

[Appsfuel Docs](http://docs.appsfuel.com/api_reference#api_integration)
