### PR TITLE
Remove SOCIAL_AUTH_CREATE_USERS reference from docs

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -472,10 +472,6 @@ Miscellaneous Settings
 
     SOCIAL_AUTH_SESSION_EXPIRATION = False
 
-- It's possible to disable user creations by ``django-social-auth`` with::
-
-      SOCIAL_AUTH_CREATE_USERS = False
-
 - If you want to store extra parameters from POST or GET in session, like it
   was made for ``next`` parameter, define this setting::
 


### PR DESCRIPTION
Doc says that we can use SOCIAL_AUTH_CREATE_USERS to cancel user creation. It's false.
