### PR TITLE
Fix the google white listed emails validation code

### DIFF
--- a/social_auth/backends/google.py
+++ b/social_auth/backends/google.py
@@ -254,9 +254,9 @@ def validate_whitelists(backend, email):
     domains = setting('GOOGLE_WHITE_LISTED_DOMAINS', [])
     if not emails and not domains:
         return True
-    if email in emails:
+    if email in set(emails):
         return True # you're good
-    if email.split('@', 1)[1] in domains:
+    if email.split('@', 1)[1] in set(domains):
         return True
     raise AuthFailed(backend, 'User not allowed')
 


### PR DESCRIPTION
The google white-list email validation code previously had a security issue where by a django application which was configured to only accept a list of emails would 'fail open' because no error was raised when the email address to validate was _not_ in the list of allowed emails and no domain was configured!
