### PR TITLE
compatibility with Django1.6

### DIFF
--- a/social_auth/backends/__init__.py
+++ b/social_auth/backends/__init__.py
@@ -18,8 +18,15 @@ from openid.extensions import sreg, ax, pape
 
 from oauth2 import Consumer as OAuthConsumer, Token, Request as OAuthRequest
 
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.contrib.auth import authenticate
-from django.utils import simplejson
 from django.utils.importlib import import_module
 
 from social_auth.models import UserSocialAuth

--- a/social_auth/backends/amazon.py
+++ b/social_auth/backends/amazon.py
@@ -2,7 +2,13 @@ import base64
 from urllib2 import Request, HTTPError
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/browserid.py
+++ b/social_auth/backends/browserid.py
@@ -3,8 +3,15 @@ BrowserID support
 """
 from urllib import urlencode
 
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.contrib.auth import authenticate
-from django.utils import simplejson
 
 from social_auth.backends import SocialAuthBackend, BaseAuth
 from social_auth.utils import log, dsa_urlopen

--- a/social_auth/backends/contrib/angel.py
+++ b/social_auth/backends/contrib/angel.py
@@ -12,7 +12,13 @@ More information on scope can be found at https://angel.co/api/oauth/faq
 """
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/bitbucket.py
+++ b/social_auth/backends/contrib/bitbucket.py
@@ -10,7 +10,13 @@ By default username, email, token expiration time, first name and last name are
 stored in extra_data field, check OAuthBackend class for details on how to
 extend it.
 """
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 from social_auth.utils import dsa_urlopen
 

--- a/social_auth/backends/contrib/dailymotion.py
+++ b/social_auth/backends/contrib/dailymotion.py
@@ -13,7 +13,13 @@ class for details on how to extend it.
 """
 from urllib2 import HTTPError
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import dsa_urlopen
 from social_auth.backends import BaseOAuth2

--- a/social_auth/backends/contrib/disqus.py
+++ b/social_auth/backends/contrib/disqus.py
@@ -1,4 +1,11 @@
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen, backend_setting
 from urllib import urlencode

--- a/social_auth/backends/contrib/douban.py
+++ b/social_auth/backends/contrib/douban.py
@@ -11,7 +11,13 @@ class for details on how to extend it.
 """
 from urllib2 import Request
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import dsa_urlopen
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend, BaseOAuth2

--- a/social_auth/backends/contrib/dropbox.py
+++ b/social_auth/backends/contrib/dropbox.py
@@ -8,7 +8,13 @@ given by Dropbox application registration process.
 By default account id and token expiration time are stored in extra_data
 field, check OAuthBackend class for details on how to extend it.
 """
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import setting
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend

--- a/social_auth/backends/contrib/foursquare.py
+++ b/social_auth/backends/contrib/foursquare.py
@@ -1,6 +1,12 @@
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/github.py
+++ b/social_auth/backends/contrib/github.py
@@ -17,7 +17,14 @@ field, check OAuthBackend class for details on how to extend it.
 from urllib import urlencode
 from urllib2 import HTTPError
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.conf import settings
 
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/instagram.py
+++ b/social_auth/backends/contrib/instagram.py
@@ -1,6 +1,12 @@
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/jawbone.py
+++ b/social_auth/backends/contrib/jawbone.py
@@ -1,6 +1,12 @@
 from urllib2 import Request, urlopen
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.exceptions import AuthCanceled, AuthUnknownError

--- a/social_auth/backends/contrib/linkedin.py
+++ b/social_auth/backends/contrib/linkedin.py
@@ -11,7 +11,13 @@ from urllib import urlencode
 from urllib2 import Request
 from oauth2 import Token
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import setting, dsa_urlopen
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend, BaseOAuth2

--- a/social_auth/backends/contrib/live.py
+++ b/social_auth/backends/contrib/live.py
@@ -16,7 +16,13 @@ AuthUnknownError - if user data retrieval fails
 """
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import dsa_urlopen
 from social_auth.backends import BaseOAuth2, OAuthBackend

--- a/social_auth/backends/contrib/mailru.py
+++ b/social_auth/backends/contrib/mailru.py
@@ -10,8 +10,15 @@ Then update your settings values using registration information
 
 """
 
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.conf import settings
-from django.utils import simplejson
 
 from urllib import urlencode, unquote
 from urllib2 import Request, HTTPError

--- a/social_auth/backends/contrib/mendeley.py
+++ b/social_auth/backends/contrib/mendeley.py
@@ -5,7 +5,13 @@ No extra configurations are needed to make this work.
 """
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 MENDELEY_SERVER = 'mendeley.com'
 MENDELEY_REQUEST_TOKEN_URL = 'http://api.%s/oauth/request_token/' % \

--- a/social_auth/backends/contrib/mixcloud.py
+++ b/social_auth/backends/contrib/mixcloud.py
@@ -4,7 +4,13 @@ Mixcloud OAuth2 support
 from urllib import urlencode
 from urllib2 import Request
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/odnoklassniki.py
+++ b/social_auth/backends/contrib/odnoklassniki.py
@@ -20,9 +20,16 @@ from urllib import urlencode, unquote
 from urllib2 import Request
 from hashlib import md5
 
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django import forms
 from django.contrib.auth import authenticate
-from django.utils import simplejson
 
 from social_auth.backends import OAuthBackend, BaseOAuth2, BaseAuth, \
                                  SocialAuthBackend

--- a/social_auth/backends/contrib/orkut.py
+++ b/social_auth/backends/contrib/orkut.py
@@ -10,7 +10,13 @@ can be specified by defining ORKUT_EXTRA_DATA setting.
 OAuth settings ORKUT_CONSUMER_KEY and ORKUT_CONSUMER_SECRET are needed
 to enable this service support.
 """
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import setting, dsa_urlopen
 from social_auth.backends import OAuthBackend

--- a/social_auth/backends/contrib/rdio.py
+++ b/social_auth/backends/contrib/rdio.py
@@ -2,7 +2,13 @@ import urllib
 
 from oauth2 import Request as OAuthRequest, SignatureMethod_HMAC_SHA1
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend, BaseOAuth2
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/readability.py
+++ b/social_auth/backends/contrib/readability.py
@@ -6,7 +6,13 @@ READABILITY_CONSUMER_KEY and READABILITY_CONSUMER_SECRET must be defined with
 the values given by Readability in the Connections page of your account
 settings."""
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 from social_auth.exceptions import AuthCanceled

--- a/social_auth/backends/contrib/skyrock.py
+++ b/social_auth/backends/contrib/skyrock.py
@@ -9,7 +9,13 @@ values.
 By default account id is stored in extra_data field, check OAuthBackend
 class for details on how to extend it.
 """
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.exceptions import AuthCanceled
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend

--- a/social_auth/backends/contrib/soundcloud.py
+++ b/social_auth/backends/contrib/soundcloud.py
@@ -14,7 +14,13 @@ field, check OAuthBackend class for details on how to extend it.
 """
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import dsa_urlopen
 from social_auth.backends import BaseOAuth2, OAuthBackend

--- a/social_auth/backends/contrib/stackoverflow.py
+++ b/social_auth/backends/contrib/stackoverflow.py
@@ -19,7 +19,14 @@ from urlparse import parse_qsl
 from gzip import GzipFile
 from StringIO import StringIO
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.conf import settings
 
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/stocktwits.py
+++ b/social_auth/backends/contrib/stocktwits.py
@@ -1,5 +1,11 @@
 from urllib import urlencode
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/trello.py
+++ b/social_auth/backends/contrib/trello.py
@@ -13,7 +13,13 @@ TRELLO_AUTH_EXTRA_ARGUMENTS = {
 into settings.py
 """
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 from social_auth.utils import dsa_urlopen, backend_setting

--- a/social_auth/backends/contrib/tumblr.py
+++ b/social_auth/backends/contrib/tumblr.py
@@ -16,7 +16,13 @@ from urllib import urlopen
 from oauth2 import Request as OAuthRequest, Token as OAuthToken, \
                    SignatureMethod_HMAC_SHA1
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import ConsumerBasedOAuth
 from social_auth.backends import OAuthBackend

--- a/social_auth/backends/contrib/vk.py
+++ b/social_auth/backends/contrib/vk.py
@@ -5,9 +5,15 @@ vk.com OpenAPI and OAuth 2.0 support.
 This contribution adds support for VK.com OpenAPI, OAuth 2.0 and IFrame apps.
 Username is retrieved from the identity returned by server.
 """
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from django.contrib.auth import authenticate
-from django.utils import simplejson
 
 from urllib import urlencode
 from hashlib import md5

--- a/social_auth/backends/contrib/weibo.py
+++ b/social_auth/backends/contrib/weibo.py
@@ -14,7 +14,13 @@ check OAuthBackend class for details on how to extend it.
 """
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import OAuthBackend, BaseOAuth2
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/contrib/xing.py
+++ b/social_auth/backends/contrib/xing.py
@@ -8,7 +8,13 @@ from oauth2 import Token
 
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 from social_auth.exceptions import AuthCanceled, AuthUnknownError

--- a/social_auth/backends/contrib/yahoo.py
+++ b/social_auth/backends/contrib/yahoo.py
@@ -20,7 +20,13 @@ Throws:
 AuthUnknownError - if user data retrieval fails (guid or profile)
 """
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 from social_auth.exceptions import AuthUnknownError

--- a/social_auth/backends/contrib/yammer.py
+++ b/social_auth/backends/contrib/yammer.py
@@ -5,7 +5,14 @@ import logging
 from urllib import urlencode
 from urlparse import parse_qs
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.utils.datastructures import MergeDict
 
 from social_auth.backends import BaseOAuth2, OAuthBackend

--- a/social_auth/backends/contrib/yandex.py
+++ b/social_auth/backends/contrib/yandex.py
@@ -6,7 +6,13 @@ openid.yandex.ru/user. Username is retrieved from the identity url.
 
 If username is not specified, OpenID 2.0 url used for authentication.
 """
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from urllib import urlencode
 from urlparse import urlparse, urlsplit

--- a/social_auth/backends/facebook.py
+++ b/social_auth/backends/facebook.py
@@ -19,7 +19,14 @@ import time
 from urllib import urlencode
 from urllib2 import HTTPError
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.contrib.auth import authenticate
 from django.http import HttpResponse
 from django.template import TemplateDoesNotExist, RequestContext, loader

--- a/social_auth/backends/google.py
+++ b/social_auth/backends/google.py
@@ -18,7 +18,13 @@ from urllib2 import Request
 
 from oauth2 import Request as OAuthRequest
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.utils import setting, dsa_urlopen
 from social_auth.backends import OpenIdAuth, ConsumerBasedOAuth, BaseOAuth2, \

--- a/social_auth/backends/reddit.py
+++ b/social_auth/backends/reddit.py
@@ -2,7 +2,13 @@ import base64
 from urllib2 import Request, HTTPError
 from urllib import urlencode
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import BaseOAuth2, OAuthBackend
 from social_auth.utils import dsa_urlopen

--- a/social_auth/backends/steam.py
+++ b/social_auth/backends/steam.py
@@ -3,7 +3,13 @@ import re
 import urllib
 import urllib2
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import OpenIdAuth, OpenIDBackend
 from social_auth.exceptions import AuthFailed

--- a/social_auth/backends/twitter.py
+++ b/social_auth/backends/twitter.py
@@ -11,7 +11,13 @@ User screen name is used to generate username.
 By default account id is stored in extra_data field, check OAuthBackend
 class for details on how to extend it.
 """
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.backends import ConsumerBasedOAuth, OAuthBackend
 from social_auth.exceptions import AuthCanceled

--- a/social_auth/backends/utils.py
+++ b/social_auth/backends/utils.py
@@ -1,7 +1,13 @@
 from oauth2 import Consumer as OAuthConsumer, Token, Request as OAuthRequest, \
                    SignatureMethod_HMAC_SHA1, HTTP_METHOD
 
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 from social_auth.models import UserSocialAuth
 from social_auth.utils import dsa_urlopen

--- a/social_auth/fields.py
+++ b/social_auth/fields.py
@@ -1,6 +1,13 @@
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils import simplejson
 from django.utils.encoding import smart_unicode
 
 

--- a/social_auth/tests/client.py
+++ b/social_auth/tests/client.py
@@ -1,8 +1,16 @@
 import urllib
+
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
+
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.test.client import Client, RequestFactory
-from django.utils import simplejson
 from django.utils.importlib import import_module
 from mock import patch
 from social_auth.views import complete


### PR DESCRIPTION
`django.utils.simplejson` has been deprecated in Django1.6, use `json` instead
