### PR TITLE
[backends] Added better error handling when parsing the <backend>_EXTRA_DATA setting

### DIFF
--- a/social_auth/exceptions.py
+++ b/social_auth/exceptions.py
@@ -5,8 +5,11 @@ class SocialAuthBaseException(ValueError):
     """Base class for pipeline exceptions."""
     pass
 
+class BackendError(SocialAuthBaseException):
+    def __unicode__(self):
+        return ugettext(u'Backend error: %s' % self.message)
 
-class WrongBackend(SocialAuthBaseException):
+class WrongBackend(BackendError):
     def __init__(self, backend_name):
         self.backend_name = backend_name
 


### PR DESCRIPTION
I ran into some very confusing errors when setting the `FOO_EXTRA_DATA` variable in `settings.py`. First, there's a bug if you set 

``` python
FOO_EXTRA_DATA = [
    ('user',)
]
```

Since the unpacking is faulty: `name = alias = entry` when it should instead be `(name,) = (alias,) = entry`.

Secondly, certain configuration errors result in a `TypeError` being thrown — which is unfortunately swallowed by [Django's auth module](https://github.com/django/django/blob/1.5.2/django/contrib/auth/__init__.py#L61). I re-worked the whole logic so that it's more thorough, and always gives visible exceptions — by instead throwing a  `BackendException` that I introduced.

Also, I made the following work:

``` python
FOO_EXTRA_DATA = [ 'user' ]
```

Note: `FOO` goes for any backend, in my case I used the Instagram one.
